### PR TITLE
Render hint text in text field label

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -1,17 +1,29 @@
 module GovukElementsFormBuilder
   class FormBuilder < ActionView::Helpers::FormBuilder
-    def text_field(name,*arg)
+    def text_field(name, *arg)
       @template.content_tag :div, class: 'form-group' do
         options = arg.extract_options!
-
-        label_class = ["form-label"]
-
         text_field_class = ["form-control"]
-
         options[:class] = text_field_class
 
-        label(name, class: label_class) + super(name, options.except(:label))
+        label = label(name, class: "form-label")
+        add_hint label, name
+        (label + super(name, options.except(:label)) ).html_safe
       end
     end
+
+    private
+
+    def add_hint label, name
+      if hint = hint_text(name)
+        hint_span = @template.content_tag(:span, hint, class: 'form-hint')
+        label.sub!('</label>', hint_span + '</label>'.html_safe)
+      end
+    end
+
+    def hint_text name
+      I18n.t("#{object_name}.#{name}", default: "", scope: 'helpers.hint').presence
+    end
+
   end
 end

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -3,4 +3,7 @@ class Person
 
   attr_accessor :name
   validates_presence_of :name
+
+  attr_accessor :ni_number
+
 end

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -25,3 +25,7 @@ en:
     label:
       person:
         name: Full name
+        ni_number: National Insurance number
+    hint:
+      person:
+        ni_number: It’ll be on your last payslip. For example, JH 21 90 0A.

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -13,15 +13,41 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
   let(:resource)  { Person.new }
   let(:builder) { described_class.new :person, resource, helper, {} }
 
-  describe '#text_field' do
-    it 'outputs correct markup' do
-      output = builder.text_field :name
-      expect(output).to eq '<div class="form-group">' +
-        '<label class="form-label" for="person_name">Full name</label>' +
-        '<input class="form-control" type="text" name="person[name]" id="person_name" />' +
-        '</div>'
-    end
+  def expect_equal output, expected
+    split_output = output.split("<").join("\n<").split(">").join(">\n").squeeze("\n").strip + '>'
+    split_expected = expected.join("\n")
+    expect(split_output).to eq split_expected
   end
 
+  describe '#text_field' do
+    it 'outputs label and input wrapped in div' do
+      output = builder.text_field :name
+      expect_equal output, [
+        '<div class="form-group">',
+        '<label class="form-label" for="person_name">',
+        'Full name',
+        '</label>',
+        '<input class="form-control" type="text" name="person[name]" id="person_name" />',
+        '</div>'
+      ]
+    end
+
+    context 'when hint text provided' do
+      it 'outputs hint text in span inside label' do
+        output = builder.text_field :ni_number
+        expect_equal output, [
+          '<div class="form-group">',
+          '<label class="form-label" for="person_ni_number">',
+          'National Insurance number',
+          '<span class="form-hint">',
+          'It’ll be on your last payslip. For example, JH 21 90 0A.',
+          '</span>',
+          '</label>',
+          '<input class="form-control" type="text" name="person[ni_number]" id="person_ni_number" />',
+          '</div>'
+        ]
+      end
+    end
+  end
 
 end


### PR DESCRIPTION
When hint text is configured in locales file for a given field render the hint text in a `span` inside the `label` when `text_field` helper method is used.

Hint markup defined in GOV.UK elements guide here: https://govuk-elements.herokuapp.com/form-elements/#form-hint-text

closes #14 