### PR TITLE
Fix password and email fields form builder methods

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -1,8 +1,9 @@
 module GovukElementsFormBuilder
   class FormBuilder < ActionView::Helpers::FormBuilder
+
     delegate :content_tag, :tag, to: :@template
 
-    %w[text_field email_field].each do |method_name|
+    %w[text_field email_field password_field].each do |method_name|
       define_method(method_name) do |name, *args |
         content_tag :div, class: 'form-group' do
           options = args.extract_options!
@@ -28,6 +29,5 @@ module GovukElementsFormBuilder
     def hint_text name
       I18n.t("#{object_name}.#{name}", default: "", scope: 'helpers.hint').presence
     end
-
   end
 end

--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -2,15 +2,17 @@ module GovukElementsFormBuilder
   class FormBuilder < ActionView::Helpers::FormBuilder
     delegate :content_tag, :tag, to: :@template
 
-    def text_field(name, *arg)
-      content_tag :div, class: 'form-group' do
-        options = arg.extract_options!
-        text_field_class = ["form-control"]
-        options[:class] = text_field_class
+    %w[text_field email_field].each do |method_name|
+      define_method(method_name) do |name, *args |
+        content_tag :div, class: 'form-group' do
+          options = args.extract_options!
+          text_field_class = ["form-control"]
+          options[:class] = text_field_class
 
-        label = label(name, class: "form-label")
-        add_hint label, name
-        (label + super(name, options.except(:label)) ).html_safe
+          label = label(name, class: "form-label")
+          add_hint label, name
+          (label + super(name, options.except(:label)) ).html_safe
+        end
       end
     end
 

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -5,5 +5,7 @@ class Person
   validates_presence_of :name
 
   attr_accessor :ni_number
+  attr_accessor :email_work
+  attr_accessor :email_home
 
 end

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -7,5 +7,7 @@ class Person
   attr_accessor :ni_number
   attr_accessor :email_work
   attr_accessor :email_home
+  attr_accessor :password
+  attr_accessor :password_confirmation
 
 end

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -24,8 +24,11 @@ en:
   helpers:
     label:
       person:
+        email_home: Home email address
+        email_work: Work email address
         name: Full name
         ni_number: National Insurance number
     hint:
       person:
+        email_home: For eg. John.Smith@example.com
         ni_number: It’ll be on your last payslip. For example, JH 21 90 0A.

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -28,7 +28,10 @@ en:
         email_work: Work email address
         name: Full name
         ni_number: National Insurance number
+        password: Password
+        password_confirmation: Confirm password
     hint:
       person:
         email_home: For eg. John.Smith@example.com
         ni_number: It’ll be on your last payslip. For example, JH 21 90 0A.
+        password_confirmation: Password should match

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -81,4 +81,35 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     end
   end
 
+  describe '#password_field' do
+    it 'outputs label and input wrapped in div' do
+      output = builder.password_field :password
+      expect_equal output, [
+        '<div class="form-group">',
+        '<label class="form-label" for="person_password">',
+        'Password',
+        '</label>',
+        '<input class="form-control" type="password" name="person[password]" id="person_password" />',
+        '</div>'
+      ]
+    end
+
+    context 'when hint text provided' do
+      it 'outputs hint text in span inside label' do
+        output = builder.password_field :password_confirmation
+        expect_equal output, [
+          '<div class="form-group">',
+          '<label class="form-label" for="person_password_confirmation">',
+          'Confirm password',
+          '<span class="form-hint">',
+          'Password should match',
+          '</span>',
+          '</label>',
+          '<input class="form-control" type="password" name="person[password_confirmation]" id="person_password_confirmation" />',
+          '</div>'
+        ]
+      end
+    end
+  end
+
 end

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -50,4 +50,35 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     end
   end
 
+  describe '#email_field' do
+    it 'outputs label and input wrapped in div' do
+      output = builder.email_field :email_work
+      expect_equal output, [
+        '<div class="form-group">',
+        '<label class="form-label" for="person_email_work">',
+        'Work email address',
+        '</label>',
+        '<input class="form-control" type="email" name="person[email_work]" id="person_email_work" />',
+        '</div>'
+      ]
+    end
+
+    context 'when hint text provided' do
+      it 'outputs hint text in span inside label' do
+        output = builder.email_field :email_home
+        expect_equal output, [
+          '<div class="form-group">',
+          '<label class="form-label" for="person_email_home">',
+          'Home email address',
+          '<span class="form-hint">',
+          'For eg. John.Smith@example.com',
+          '</span>',
+          '</label>',
+          '<input class="form-control" type="email" name="person[email_home]" id="person_email_home" />',
+          '</div>'
+        ]
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Fixes #21
1. Added email and password attributes to the Person model.
2. Now applies GDS markup around email and password fields