### PR TITLE
Add helper method to generate activemodel error summary box

### DIFF
--- a/app/helpers/govuk_elements_errors_helper.rb
+++ b/app/helpers/govuk_elements_errors_helper.rb
@@ -1,0 +1,63 @@
+module GovukElementsErrorsHelper
+
+  class << self
+    include ActionView::Context
+    include ActionView::Helpers::TagHelper
+  end
+
+  def self.error_summary object, heading, description
+    return if object.errors.blank?
+    error_summary_div do
+      error_summary_heading(heading) +
+      error_summary_description(description) +
+      error_summary_messages(object)
+    end
+  end
+
+  def self.error_summary_div &block
+    content_tag(:div,
+        class: 'error-summary',
+        role: 'group',
+        aria: {
+          labelledby: 'error-summary-heading'
+        },
+        tabindex: '-1') do
+      yield block
+    end
+  end
+
+  def self.error_summary_heading text
+    content_tag :h1,
+      text,
+      id: 'error-summary-heading',
+      class: 'heading-medium error-summary-heading'
+  end
+
+  def self.error_summary_description text
+    content_tag :p, text
+  end
+
+  def self.error_summary_messages object
+    content_tag(:ul,
+        class: 'error-summary-list') do
+      prefix = object.class.name.underscore
+
+      object.errors.keys.map do |attribute|
+        error_summary_message object, prefix, attribute
+      end.flatten.join('').html_safe
+    end
+  end
+
+  def self.error_summary_message object, prefix, attribute
+    messages = object.errors.full_messages_for attribute
+    messages.map do |message|
+      content_tag(:li, content_tag(:a, message, href: "#error_#{prefix}_#{attribute}"))
+    end
+  end
+
+  private_class_method :error_summary_div
+  private_class_method :error_summary_heading
+  private_class_method :error_summary_description
+  private_class_method :error_summary_messages
+
+end

--- a/govuk_elements_form_builder.gemspec
+++ b/govuk_elements_form_builder.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = "Custom Ruby on Rails form builder that generates GOV.UK elements styled markup for form inputs, including error validation messages."
   s.license     = "MIT"
 
-  s.files = Dir["{lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
+  s.files = Dir["{app,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
   s.add_dependency "rails", "~> 4.2"
 

--- a/lib/govuk_elements_form_builder.rb
+++ b/lib/govuk_elements_form_builder.rb
@@ -1,5 +1,6 @@
 require 'govuk_elements_form_builder/version'
 require 'govuk_elements_form_builder/form_builder'
+require_relative '../app/helpers/govuk_elements_errors_helper'
 
 module GovukElementsFormBuilder
 end

--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -41,7 +41,7 @@ module GovukElementsFormBuilder
     def add_error_to_label! html_tag
       field = html_tag[/for="([^"]+)"/, 1]
       attribute = field.sub(@object_name.to_s + '_', '').to_sym
-      message = errors.full_messages_for(attribute).first
+      message = error_full_message_for attribute
       html_tag.sub!('label', %'label id="error_#{field}"')
       html_tag.sub!('</label',
         %'<span class="error-message" id="error_message_#{field}">#{message}</span></label')
@@ -56,6 +56,13 @@ module GovukElementsFormBuilder
       classes = 'form-group'
       classes += ' error' if error_for? attribute
       classes
+    end
+
+    def error_full_message_for attribute
+      message = errors.full_messages_for(attribute).first
+      label = attribute.to_s.humanize.capitalize
+      message.sub!(label, label_text(attribute))
+      message
     end
 
     def error_for? attribute
@@ -74,7 +81,15 @@ module GovukElementsFormBuilder
     end
 
     def hint_text name
-      I18n.t("#{object_name}.#{name}", default: "", scope: 'helpers.hint').presence
+      I18n.t("#{object_name}.#{name}",
+        default: '',
+        scope: 'helpers.hint').presence
+    end
+
+    def label_text attribute
+      I18n.t("#{object_name}.#{attribute}",
+        default: attribute.to_s.humanize.capitalize,
+        scope: 'helpers.label').presence
     end
   end
 end

--- a/spec/helpers/govuk_elements_errors_helper_spec.rb
+++ b/spec/helpers/govuk_elements_errors_helper_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe GovukElementsErrorsHelper, type: :helper do
+
+  let(:resource)  { Person.new }
+  let(:error_summary_heading) { 'Message to alert the user to a problem goes here' }
+  let(:error_summary_description) { 'Optional description of the errors and how to correct them' }
+
+  describe '#error_summary when object has validation errors' do
+    it 'outputs error full messages' do
+      resource.valid?
+      output = described_class.error_summary resource, error_summary_heading, error_summary_description
+      expect(output.split('>').join(">\n")).to eq ('<div ' +
+          'class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">' +
+        '<h1 id="error-summary-heading" class="heading-medium error-summary-heading">' +
+          error_summary_heading +
+        '</h1>' +
+        '<p>' +
+          error_summary_description +
+        '</p>' +
+        '<ul class="error-summary-list">' +
+          '<li><a href="#error_person_name">Name can&#39;t be blank</a></li>' +
+        '</ul>' +
+      '</div>').split('>').join(">\n")
+    end
+  end
+
+  describe '#error_summary when object does not have validation errors' do
+    it 'outputs nil' do
+      output = described_class.error_summary resource, error_summary_heading, error_summary_description
+      expect(output).to eq nil
+    end
+  end
+
+end

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
           '<label id="error_person_name" class="form-label" for="person_name">',
           'Full name',
           '<span class="error-message" id="error_message_person_name">',
-          "Name can't be blank",
+          "Full name can't be blank",
           '</span>',
           '</label>',
           '<input aria-describedby="error_message_person_name" class="form-control" type="text" name="person[name]" id="person_name" />',


### PR DESCRIPTION
Generate error summary markup as defined in the GOV.UK elements guide here:
https://govuk-elements.herokuapp.com/errors/#summarise-errors

Maybe enhance later to take error summary heading and description text from locales file.

Closes: #4