### PR TITLE
Add error message inside field label and add error classes

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -2,22 +2,69 @@ module GovukElementsFormBuilder
   class FormBuilder < ActionView::Helpers::FormBuilder
 
     delegate :content_tag, :tag, to: :@template
+    delegate :errors, to: :@object
+
+    def initialize *args
+      ActionView::Base.field_error_proc = Proc.new do |html_tag, instance|
+        add_error_to_html_tag! html_tag
+      end
+      super
+    end
 
     %w[text_field email_field password_field].each do |method_name|
-      define_method(method_name) do |name, *args |
-        content_tag :div, class: 'form-group' do
+      define_method(method_name) do |attribute, *args|
+        content_tag :div, class: form_group_classes(attribute) do
           options = args.extract_options!
           text_field_class = ["form-control"]
           options[:class] = text_field_class
 
-          label = label(name, class: "form-label")
-          add_hint label, name
-          (label + super(name, options.except(:label)) ).html_safe
+          label = label(attribute, class: "form-label")
+          add_hint label, attribute
+          (label + super(attribute, options.except(:label)) ).html_safe
         end
       end
     end
 
     private
+
+    def add_error_to_html_tag! html_tag
+      case html_tag
+      when /^<label/
+        add_error_to_label! html_tag
+      when /^<input/
+        add_error_to_input! html_tag
+      else
+        html_tag
+      end
+    end
+
+    def add_error_to_label! html_tag
+      field = html_tag[/for="([^"]+)"/, 1]
+      attribute = field.sub(@object_name.to_s + '_', '').to_sym
+      message = errors.full_messages_for(attribute).first
+      html_tag.sub!('label', %'label id="error_#{field}"')
+      html_tag.sub!('</label',
+        %'<span class="error-message" id="error_message_#{field}">#{message}</span></label')
+    end
+
+    def add_error_to_input! html_tag
+      field = html_tag[/id="([^"]+)"/, 1]
+      html_tag.sub!('input', %'input aria-describedby="error_message_#{field}"')
+    end
+
+    def form_group_classes attribute
+      classes = 'form-group'
+      classes += ' error' if error_for? attribute
+      classes
+    end
+
+    def error_for? attribute
+      errors.messages.key?(attribute) && !errors.messages[attribute].empty?
+    end
+
+    def error_id attribute
+      "error-#{@object_name.tr('[]','-')}-#{attribute}".squeeze('-')
+    end
 
     def add_hint label, name
       if hint = hint_text(name)

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
   describe '#text_field' do
     it 'outputs label and input wrapped in div' do
       output = builder.text_field :name
+
       expect_equal output, [
         '<div class="form-group">',
         '<label class="form-label" for="person_name">',
@@ -44,6 +45,25 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
           '</span>',
           '</label>',
           '<input class="form-control" type="text" name="person[ni_number]" id="person_ni_number" />',
+          '</div>'
+        ]
+      end
+    end
+
+    context 'when validation error on object' do
+      it 'outputs error message in span inside label' do
+        resource.valid?
+        output = builder.text_field :name
+
+        expect_equal output, [
+          '<div class="form-group error">',
+          '<label id="error_person_name" class="form-label" for="person_name">',
+          'Full name',
+          '<span class="error-message" id="error_message_person_name">',
+          "Name can't be blank",
+          '</span>',
+          '</label>',
+          '<input aria-describedby="error_message_person_name" class="form-control" type="text" name="person[name]" id="person_name" />',
           '</div>'
         ]
       end


### PR DESCRIPTION
Add GOV.UK elements error classes to field elements and add error message span inside field label element.

Closes #16