### PR TITLE
Add text_area method and spec fields_for with hint text works

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -17,7 +17,12 @@ module GovukElementsFormBuilder
       super attribute, options.merge(builder: self.class)
     end
 
-    %w[text_field email_field password_field].each do |method_name|
+    %w[
+      email_field
+      password_field
+      text_area
+      text_field
+    ].each do |method_name|
       define_method(method_name) do |attribute, *args|
         content_tag :div, class: form_group_classes(attribute), id: form_group_id(attribute) do
           options = args.extract_options!

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -30,8 +30,12 @@ en:
         ni_number: National Insurance number
         password: Password
         password_confirmation: Confirm password
+      person[address_attributes]:
+        address: Full address
     hint:
       person:
         email_home: For eg. John.Smith@example.com
         ni_number: It’ll be on your last payslip. For example, JH 21 90 0A.
         password_confirmation: Password should match
+      person[address_attributes]:
+        address: Exclude postcode. For example, 102 Petty France, London

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -111,6 +111,29 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
   end
 
+  describe '#text_area' do
+    context 'when fields_for used' do
+      it 'outputs label and input with correct ids and hint text in span' do
+        resource.address = Address.new
+        output = builder.fields_for(:address) do |f|
+          f.text_area :address
+        end
+        expect_equal output, [
+          '<div class="form-group">',
+          '<label class="form-label" for="person_address_attributes_address">',
+          'Full address',
+          '<span class="form-hint">',
+          'Exclude postcode. For example, 102 Petty France, London',
+          '</span>',
+          '</label>',
+          '<textarea class="form-control" name="person[address_attributes][address]" id="person_address_attributes_address">',
+          '</textarea>',
+          '</div>'
+        ]
+      end
+    end
+  end
+
   describe '#email_field' do
     it 'outputs label and input wrapped in div' do
       output = builder.email_field :email_work


### PR DESCRIPTION
Add `text_area` method to form builder.

Spec label and hint text is picked up correctly from locales file when `fields_for` is used.