### PR TITLE
Show child object errors in error summary

### DIFF
--- a/app/helpers/govuk_elements_errors_helper.rb
+++ b/app/helpers/govuk_elements_errors_helper.rb
@@ -10,7 +10,7 @@ module GovukElementsErrorsHelper
     error_summary_div do
       error_summary_heading(heading) +
       error_summary_description(description) +
-      error_summary_messages(object)
+      error_summary_list(object)
     end
   end
 
@@ -62,22 +62,37 @@ module GovukElementsErrorsHelper
     content_tag :p, text
   end
 
-  def self.error_summary_messages object
-    content_tag(:ul,
-        class: 'error-summary-list') do
-      prefix = object.class.name.underscore
+  def self.error_summary_list object
+    content_tag(:ul, class: 'error-summary-list') do
+      messages = error_summary_messages(object)
 
-      object.errors.keys.map do |attribute|
-        error_summary_message object, prefix, attribute
-      end.flatten.join('').html_safe
+      messages << children_with_errors(object).map do |o|
+        error_summary_messages(o, object)
+      end
+
+      messages.flatten.join('').html_safe
     end
   end
 
-  def self.error_summary_message object, prefix, attribute
+  def self.error_summary_messages object, parent=nil
+    object.errors.keys.map do |attribute|
+      error_summary_message object, attribute, parent
+    end
+  end
+
+  def self.error_summary_message object, attribute, parent
     messages = object.errors.full_messages_for attribute
     messages.map do |message|
-      content_tag(:li, content_tag(:a, message, href: "#error_#{prefix}_#{attribute}"))
+      content_tag(:li, content_tag(:a, message, href: link_to_error(object, attribute, parent)))
     end
+  end
+
+  def self.link_to_error object, attribute, parent
+    prefix = object.class.name.underscore
+    if parent
+      prefix = "#{parent.class.name.underscore}_#{prefix}_attributes"
+    end
+    "#error_#{prefix}_#{attribute}"
   end
 
   private_class_method :error_summary_div

--- a/app/helpers/govuk_elements_errors_helper.rb
+++ b/app/helpers/govuk_elements_errors_helper.rb
@@ -15,13 +15,28 @@ module GovukElementsErrorsHelper
   end
 
   def self.errors_exist? object
-    object.errors.present? ||
-      object.instance_variables.any? do |var|
-        field = var.to_s.sub('@','').to_sym
-        object.send(field) &&
-          object.send(field).respond_to?(:errors) &&
-          object.send(field).errors.present?
-      end
+    errors_present?(object) || child_errors_present?(object)
+  end
+
+  def self.child_errors_present? object
+    attributes(object).any? { |child| errors_present?(child) }
+  end
+
+  def self.attributes object
+    object.instance_variables.map { |var| instance_variable(object, var) }
+  end
+
+  def self.instance_variable object, var
+    field = var.to_s.sub('@','').to_sym
+    object.send(field)
+  end
+
+  def self.errors_present? object
+    object && object.respond_to?(:errors) && object.errors.present?
+  end
+
+  def self.children_with_errors object
+    attributes(object).select { |child| errors_present?(child) }
   end
 
   def self.error_summary_div &block

--- a/app/helpers/govuk_elements_errors_helper.rb
+++ b/app/helpers/govuk_elements_errors_helper.rb
@@ -6,12 +6,22 @@ module GovukElementsErrorsHelper
   end
 
   def self.error_summary object, heading, description
-    return if object.errors.blank?
+    return unless errors_exist? object
     error_summary_div do
       error_summary_heading(heading) +
       error_summary_description(description) +
       error_summary_messages(object)
     end
+  end
+
+  def self.errors_exist? object
+    object.errors.present? ||
+      object.instance_variables.any? do |var|
+        field = var.to_s.sub('@','').to_sym
+        object.send(field) &&
+          object.send(field).respond_to?(:errors) &&
+          object.send(field).errors.present?
+      end
   end
 
   def self.error_summary_div &block

--- a/spec/helpers/govuk_elements_errors_helper_spec.rb
+++ b/spec/helpers/govuk_elements_errors_helper_spec.rb
@@ -6,11 +6,15 @@ RSpec.describe GovukElementsErrorsHelper, type: :helper do
   let(:error_summary_heading) { 'Message to alert the user to a problem goes here' }
   let(:error_summary_description) { 'Optional description of the errors and how to correct them' }
 
+  def split_html output
+    output.split('>').join(">\n")
+  end
+
   describe '#error_summary when object has validation errors' do
     it 'outputs error full messages' do
       resource.valid?
       output = described_class.error_summary resource, error_summary_heading, error_summary_description
-      expect(output.split('>').join(">\n")).to eq ('<div ' +
+      expect(split_html(output)).to eq split_html('<div ' +
           'class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">' +
         '<h1 id="error-summary-heading" class="heading-medium error-summary-heading">' +
           error_summary_heading +
@@ -21,7 +25,29 @@ RSpec.describe GovukElementsErrorsHelper, type: :helper do
         '<ul class="error-summary-list">' +
           '<li><a href="#error_person_name">Name can&#39;t be blank</a></li>' +
         '</ul>' +
-      '</div>').split('>').join(">\n")
+      '</div>')
+    end
+  end
+
+  describe '#error_summary when child object has validation errors' do
+    it 'outputs error full messages of child object' do
+      resource.address = Address.new
+      resource.address.valid?
+
+      output = described_class.error_summary resource, error_summary_heading, error_summary_description
+      expect(output).to_not be_nil
+      expect(split_html(output)).to eq split_html('<div ' +
+          'class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">' +
+        '<h1 id="error-summary-heading" class="heading-medium error-summary-heading">' +
+          error_summary_heading +
+        '</h1>' +
+        '<p>' +
+          error_summary_description +
+        '</p>' +
+        '<ul class="error-summary-list">' +
+          '<li><a href="#error_person_name">Postcode can&#39;t be blank</a></li>' +
+        '</ul>' +
+      '</div>')
     end
   end
 

--- a/spec/helpers/govuk_elements_errors_helper_spec.rb
+++ b/spec/helpers/govuk_elements_errors_helper_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe GovukElementsErrorsHelper, type: :helper do
           error_summary_description +
         '</p>' +
         '<ul class="error-summary-list">' +
-          '<li><a href="#error_person_name">Postcode can&#39;t be blank</a></li>' +
+          '<li><a href="#error_person_address_attributes_postcode">Postcode can&#39;t be blank</a></li>' +
         '</ul>' +
       '</div>')
     end


### PR DESCRIPTION
- Identify attributes of object that have errors on them.
- Generate error message for each child object error.
- Add error messages to error summary list.

A followup pull request will get localized labels working on the error message text.

Closes #32