### PR TITLE
Handle fields_for() being nested more than once in form_for()

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -59,8 +59,8 @@ module GovukElementsFormBuilder
 
     def add_error_to_label! html_tag
       field = html_tag[/for="([^"]+)"/, 1]
-      attribute = field.sub(@object_name.to_s + '_', '').to_sym
-      message = error_full_message_for attribute
+      object_attribute = object_attribute_for field
+      message = error_full_message_for object_attribute
       html_tag.sub!('</label',
         %'<span class="error-message" id="error_message_#{field}">#{message}</span></label')
     end
@@ -77,10 +77,8 @@ module GovukElementsFormBuilder
     end
 
     def error_full_message_for attribute
-      object_attribute = adjust_nested_object_attribute attribute
-      message = errors.full_messages_for(object_attribute).first
-      label = attribute.to_s.humanize.capitalize
-      message.sub!(label, label_text(attribute))
+      message = errors.full_messages_for(attribute).first
+      message.sub! default_label(attribute), localized_label(attribute)
       message
     end
 
@@ -88,18 +86,10 @@ module GovukElementsFormBuilder
       errors.messages.key?(attribute) && !errors.messages[attribute].empty?
     end
 
-    def adjust_nested_object_attribute attribute
-      if parent_builder?
-        attribute.to_s.
-          sub("#{attribute_prefix}_", '').
-          to_sym
-      else
-        attribute
-      end
-    end
-
-    def parent_builder?
-      options[:parent_builder].present?
+    def object_attribute_for field
+      field.to_s.
+        sub("#{attribute_prefix}_", '').
+        to_sym
     end
 
     def add_hint label, name
@@ -115,9 +105,14 @@ module GovukElementsFormBuilder
         scope: 'helpers.hint').presence
     end
 
-    def label_text attribute
-      I18n.t("#{object_name}.#{attribute}",
-        default: attribute.to_s.humanize.capitalize,
+    def default_label attribute
+      attribute.to_s.humanize.capitalize
+    end
+
+    def localized_label attribute
+      key = "#{object_name}.#{attribute}"
+      I18n.t(key,
+        default: default_label(attribute),
         scope: 'helpers.label').presence
     end
   end

--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -50,7 +50,7 @@ module GovukElementsFormBuilder
     end
 
     def attribute_prefix
-      @object_name.to_s.tr('[]','_').chomp('_')
+      @object_name.to_s.tr('[]','_').squeeze('_').chomp('_')
     end
 
     def form_group_id attribute

--- a/spec/dummy/app/models/address.rb
+++ b/spec/dummy/app/models/address.rb
@@ -5,4 +5,9 @@ class Address
   attr_accessor :postcode
   validates_presence_of :postcode
 
+  attr_accessor :country
+
+  def country_attributes=(attributes)
+    @country = Country.new(attributes)
+  end
 end

--- a/spec/dummy/app/models/country.rb
+++ b/spec/dummy/app/models/country.rb
@@ -1,0 +1,7 @@
+class Country
+  include ActiveModel::Model
+
+  attr_accessor :name
+  validates_presence_of :name
+
+end

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -32,6 +32,8 @@ en:
         password_confirmation: Confirm password
       person[address_attributes]:
         address: Full address
+      person[address_attributes][country_attributes]:
+        name: Country
     hint:
       person:
         email_home: For eg. John.Smith@example.com

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -124,9 +124,9 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
         expect_equal output, [
           '<div class="form-group error" id="error_person_address_attributes_country_attributes_name">',
           '<label class="form-label" for="person_address_attributes_country_attributes_name">',
-          'Name',
+          'Country',
           '<span class="error-message" id="error_message_person_address_attributes_country_attributes_name">',
-          "Name can't be blank",
+          "Country can't be blank",
           '</span>',
           '</label>',
           '<input aria-describedby="error_message_person_address_attributes_country_attributes_name" class="form-control" type="text" name="person[address_attributes][country_attributes][name]" id="person_address_attributes_country_attributes_name" />',

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -109,6 +109,32 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       end
     end
 
+    context 'when validation error on twice nested child object' do
+      it 'outputs error message in span inside label' do
+        resource.address = Address.new
+        resource.address.country = Country.new
+        resource.address.country.valid?
+
+        output = builder.fields_for(:address) do |address|
+          address.fields_for(:country) do |country|
+            country.text_field :name
+          end
+        end
+
+        expect_equal output, [
+          '<div class="form-group error" id="error_person_address_attributes_country_attributes_name">',
+          '<label class="form-label" for="person_address_attributes_country_attributes_name">',
+          'Name',
+          '<span class="error-message" id="error_message_person_address_attributes_country_attributes_name">',
+          "Name can't be blank",
+          '</span>',
+          '</label>',
+          '<input aria-describedby="error_message_person_address_attributes_country_attributes_name" class="form-control" type="text" name="person[address_attributes][country_attributes][name]" id="person_address_attributes_country_attributes_name" />',
+          '</div>'
+        ]
+      end
+    end
+
   end
 
   describe '#text_area' do


### PR DESCRIPTION
- Output error message in span inside label when validation error on twice nested child object.
- Use localized labels on nested child object error messages.

Closes: #35 