### PR TITLE
Use localized label on nested object message in error summary

### DIFF
--- a/app/helpers/govuk_elements_errors_helper.rb
+++ b/app/helpers/govuk_elements_errors_helper.rb
@@ -19,16 +19,33 @@ module GovukElementsErrorsHelper
   end
 
   def self.child_errors_present? object
-    attributes(object).any? { |child| errors_present?(child) }
+    attributes(object).any? { |child| errors_exist?(child) }
   end
 
   def self.attributes object
-    object.instance_variables.map { |var| instance_variable(object, var) }
+    child_objects = attribute_objects object
+    nested_child_objects = child_objects.map { |o| attributes(o) }
+    (child_objects + nested_child_objects).flatten
+  end
+
+  def self.attribute_objects object
+    object.
+      instance_variables.
+      map { |var| instance_variable(object, var) }.
+      compact
+  end
+
+  def self.child_to_parent object, parents={}
+    attribute_objects(object).each do |child|
+      parents[child] = object
+      child_to_parent child, parents
+    end
+    parents
   end
 
   def self.instance_variable object, var
     field = var.to_s.sub('@','').to_sym
-    object.send(field)
+    object.send(field) if object.respond_to?(field)
   end
 
   def self.errors_present? object
@@ -64,35 +81,76 @@ module GovukElementsErrorsHelper
 
   def self.error_summary_list object
     content_tag(:ul, class: 'error-summary-list') do
-      messages = error_summary_messages(object)
+      child_to_parents = child_to_parent(object)
+      messages = error_summary_messages(object, child_to_parents)
 
-      messages << children_with_errors(object).map do |o|
-        error_summary_messages(o, object)
+      messages << children_with_errors(object).map do |child|
+        error_summary_messages(child, child_to_parents)
       end
 
       messages.flatten.join('').html_safe
     end
   end
 
-  def self.error_summary_messages object, parent=nil
+  def self.error_summary_messages object, child_to_parents
     object.errors.keys.map do |attribute|
-      error_summary_message object, attribute, parent
+      error_summary_message object, attribute, child_to_parents
     end
   end
 
-  def self.error_summary_message object, attribute, parent
+  def self.error_summary_message object, attribute, child_to_parents
     messages = object.errors.full_messages_for attribute
     messages.map do |message|
-      content_tag(:li, content_tag(:a, message, href: link_to_error(object, attribute, parent)))
+      object_prefixes = object_prefixes object, child_to_parents
+      link = link_to_error(object_prefixes, attribute)
+      message.sub! default_label(attribute), localized_label(object_prefixes, attribute)
+      content_tag(:li, content_tag(:a, message, href: link))
     end
   end
 
-  def self.link_to_error object, attribute, parent
-    prefix = object.class.name.underscore
-    if parent
-      prefix = "#{parent.class.name.underscore}_#{prefix}_attributes"
+  def self.link_to_error object_prefixes, attribute
+    ['#error', *object_prefixes, attribute].join('_')
+  end
+
+  def self.default_label attribute
+    attribute.to_s.humanize.capitalize
+  end
+
+  def self.localized_label object_prefixes, attribute
+    object_key = object_prefixes.shift
+    object_prefixes.each { |prefix| object_key += "[#{prefix}]" }
+    key = "#{object_key}.#{attribute}"
+    I18n.t(key,
+      default: default_label(attribute),
+      scope: 'helpers.label').presence
+  end
+
+  def self.parents_list object, child_to_parents
+    if parent = child_to_parents[object]
+      [].tap do |parents|
+        while parent
+          parents.unshift parent
+          parent = child_to_parents[parent]
+        end
+      end
     end
-    "#error_#{prefix}_#{attribute}"
+  end
+
+  def self.object_prefixes object, child_to_parents
+    parents = parents_list object, child_to_parents
+
+    if parents.present?
+      root = parents.shift
+      prefixes = [underscore_name(root)]
+      parents.each { |p| prefixes << "#{underscore_name p}_attributes" }
+      prefixes << "#{underscore_name object}_attributes"
+    else
+      prefixes = [underscore_name(object)]
+    end
+  end
+
+  def self.underscore_name object
+    object.class.name.underscore
   end
 
   private_class_method :error_summary_div

--- a/spec/helpers/govuk_elements_errors_helper_spec.rb
+++ b/spec/helpers/govuk_elements_errors_helper_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe GovukElementsErrorsHelper, type: :helper do
           error_summary_description +
         '</p>' +
         '<ul class="error-summary-list">' +
-          '<li><a href="#error_person_name">Name can&#39;t be blank</a></li>' +
+          '<li><a href="#error_person_name">Full name can&#39;t be blank</a></li>' +
         '</ul>' +
       '</div>')
     end
@@ -46,6 +46,29 @@ RSpec.describe GovukElementsErrorsHelper, type: :helper do
         '</p>' +
         '<ul class="error-summary-list">' +
           '<li><a href="#error_person_address_attributes_postcode">Postcode can&#39;t be blank</a></li>' +
+        '</ul>' +
+      '</div>')
+    end
+  end
+
+  describe '#error_summary when twice nested child object has validation errors' do
+    it 'outputs error full messages of child object' do
+      resource.address = Address.new
+      resource.address.country = Country.new
+      resource.address.country.valid?
+
+      output = described_class.error_summary resource, error_summary_heading, error_summary_description
+      expect(output).to_not be_nil
+      expect(split_html(output)).to eq split_html('<div ' +
+          'class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">' +
+        '<h1 id="error-summary-heading" class="heading-medium error-summary-heading">' +
+          error_summary_heading +
+        '</h1>' +
+        '<p>' +
+          error_summary_description +
+        '</p>' +
+        '<ul class="error-summary-list">' +
+          '<li><a href="#error_person_address_attributes_country_attributes_name">Country can&#39;t be blank</a></li>' +
         '</ul>' +
       '</div>')
     end


### PR DESCRIPTION
Use localized label on nested object attribute error message in error summary box.

Generate link anchor correctly for nested object attribute error link.

Closes #25