### PR TITLE
Fail fast when running specs via guard

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -24,7 +24,7 @@
 #  * zeus: 'zeus rspec' (requires the server to be started separately)
 #  * 'just' rspec: 'rspec'
 
-guard :rspec, cmd: "bundle exec rspec" do
+guard :rspec, cmd: "bundle exec rspec --fail-fast" do
   require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)
 


### PR DESCRIPTION
Makes it easier to focus on fixing one failing spec at a time.