### PR TITLE
Add radio_button_fieldset helper to generate radio buttons

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -37,14 +37,14 @@ module GovukElementsFormBuilder
     end
 
     def radio_button_fieldset attribute, legend, options={}
-      options[:choice] ||= { 'Yes': 'yes', 'No': 'no' }
+      choices = options[:choices] || [ :yes, :no ]
       content_tag :fieldset do
         safe_join([
           content_tag(:legend, legend, class: 'visuallyhidden'),
 
-          options[:choice].map do |label_text, choice|
+          choices.map do |choice|
             label(attribute, class: 'block-label', value: choice) do |tag|
-              radio_button(attribute, choice) + label_text
+              radio_button(attribute, choice) + localized_label("#{attribute}.#{choice}")
             end
           end
         ], "\n")
@@ -121,7 +121,7 @@ module GovukElementsFormBuilder
     end
 
     def default_label attribute
-      attribute.to_s.humanize.capitalize
+      attribute.to_s.split('.').last.humanize.capitalize
     end
 
     def localized_label attribute

--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -40,7 +40,9 @@ module GovukElementsFormBuilder
       choices = options[:choices] || [ :yes, :no ]
       legend = content_tag(:legend, fieldset_text(attribute), class: 'heading-medium')
       add_hint :legend, legend, attribute
-      content_tag :fieldset do
+      fieldset_options = {}
+      fieldset_options[:class] = 'inline' if options[:inline] == true
+      content_tag :fieldset, fieldset_options do
         safe_join([
           legend.html_safe,
           choices.map do |choice|

--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -1,7 +1,7 @@
 module GovukElementsFormBuilder
   class FormBuilder < ActionView::Helpers::FormBuilder
 
-    delegate :content_tag, :tag, to: :@template
+    delegate :content_tag, :tag, :safe_join, :radio_button_tag, to: :@template
     delegate :errors, to: :@object
 
     def initialize *args
@@ -34,6 +34,26 @@ module GovukElementsFormBuilder
           (label + super(attribute, options.except(:label)) ).html_safe
         end
       end
+    end
+
+    def collection_radio_buttons(attribute, records, record_id, record_name)
+
+      content_tag(:h1, "Gender", class: 'heading-medium') +
+      content_tag(:fieldset,
+        content_tag(:legend, "Gender", class:'visuallyhidden') +
+        safe_join(records.map do | record |
+
+          element_id = "#{object_name}_#{attribute}_#{record.send(record_id)}"
+
+          label(attribute, class: "block-label") do | label |
+
+            radio_button_tag( "#{object_name}[#{attribute}][]", record.send(record_name) )
+            
+          end
+
+        end)
+      )
+      #.html_safe
     end
 
     private

--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -36,24 +36,19 @@ module GovukElementsFormBuilder
       end
     end
 
-    def collection_radio_buttons(attribute, records, record_id, record_name)
+    def radio_button_fieldset attribute, legend, options={}
+      options[:choice] ||= { 'Yes': 'yes', 'No': 'no' }
+      content_tag :fieldset do
+        safe_join([
+          content_tag(:legend, legend, class: 'visuallyhidden'),
 
-      content_tag(:h1, "Gender", class: 'heading-medium') +
-      content_tag(:fieldset,
-        content_tag(:legend, "Gender", class:'visuallyhidden') +
-        safe_join(records.map do | record |
-
-          element_id = "#{object_name}_#{attribute}_#{record.send(record_id)}"
-
-          label(attribute, class: "block-label") do | label |
-
-            radio_button_tag( "#{object_name}[#{attribute}][]", record.send(record_name) )
-            
+          options[:choice].map do |label_text, choice|
+            label(attribute, class: 'block-label', value: choice) do |tag|
+              radio_button(attribute, choice) + label_text
+            end
           end
-
-        end)
-      )
-      #.html_safe
+        ], "\n")
+      end
     end
 
     private

--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -30,7 +30,7 @@ module GovukElementsFormBuilder
           options[:class] = text_field_class
 
           label = label(attribute, class: "form-label")
-          add_hint label, attribute
+          add_hint :label, label, attribute
           (label + super(attribute, options.except(:label)) ).html_safe
         end
       end
@@ -38,10 +38,11 @@ module GovukElementsFormBuilder
 
     def radio_button_fieldset attribute, options={}
       choices = options[:choices] || [ :yes, :no ]
+      legend = content_tag(:legend, fieldset_text(attribute), class: 'heading-medium')
+      add_hint :legend, legend, attribute
       content_tag :fieldset do
         safe_join([
-          content_tag(:legend, fieldset_text(attribute), class: 'visuallyhidden'),
-
+          legend.html_safe,
           choices.map do |choice|
             label(attribute, class: 'block-label', value: choice) do |tag|
               radio_button(attribute, choice) + localized_label("#{attribute}.#{choice}")
@@ -107,10 +108,10 @@ module GovukElementsFormBuilder
         to_sym
     end
 
-    def add_hint label, name
+    def add_hint tag, element, name
       if hint = hint_text(name)
         hint_span = content_tag(:span, hint, class: 'form-hint')
-        label.sub!('</label>', hint_span + '</label>'.html_safe)
+        element.sub!("</#{tag}>", "#{hint_span}</#{tag}>".html_safe)
       end
     end
 

--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -36,11 +36,11 @@ module GovukElementsFormBuilder
       end
     end
 
-    def radio_button_fieldset attribute, legend, options={}
+    def radio_button_fieldset attribute, options={}
       choices = options[:choices] || [ :yes, :no ]
       content_tag :fieldset do
         safe_join([
-          content_tag(:legend, legend, class: 'visuallyhidden'),
+          content_tag(:legend, fieldset_text(attribute), class: 'visuallyhidden'),
 
           choices.map do |choice|
             label(attribute, class: 'block-label', value: choice) do |tag|
@@ -114,10 +114,12 @@ module GovukElementsFormBuilder
       end
     end
 
-    def hint_text name
-      I18n.t("#{object_name}.#{name}",
-        default: '',
-        scope: 'helpers.hint').presence
+    def fieldset_text attribute
+      localized 'helpers.fieldset', attribute, default_label(attribute)
+    end
+
+    def hint_text attribute
+      localized 'helpers.hint', attribute, ''
     end
 
     def default_label attribute
@@ -125,10 +127,14 @@ module GovukElementsFormBuilder
     end
 
     def localized_label attribute
+      localized 'helpers.label', attribute, default_label(attribute)
+    end
+
+    def localized scope, attribute, default
       key = "#{object_name}.#{attribute}"
       I18n.t(key,
-        default: default_label(attribute),
-        scope: 'helpers.label').presence
+        default: default,
+        scope: scope).presence
     end
   end
 end

--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -1,7 +1,7 @@
 module GovukElementsFormBuilder
   class FormBuilder < ActionView::Helpers::FormBuilder
 
-    delegate :content_tag, :tag, :safe_join, :radio_button_tag, to: :@template
+    delegate :content_tag, :tag, :safe_join, to: :@template
     delegate :errors, to: :@object
 
     def initialize *args
@@ -17,7 +17,7 @@ module GovukElementsFormBuilder
       super attribute, options.merge(builder: self.class)
     end
 
-    %w[
+    %i[
       email_field
       password_field
       text_area
@@ -37,24 +37,37 @@ module GovukElementsFormBuilder
     end
 
     def radio_button_fieldset attribute, options={}
-      choices = options[:choices] || [ :yes, :no ]
-      legend = content_tag(:legend, fieldset_text(attribute), class: 'heading-medium')
-      add_hint :legend, legend, attribute
-      fieldset_options = {}
-      fieldset_options[:class] = 'inline' if options[:inline] == true
-      content_tag :fieldset, fieldset_options do
+      content_tag :fieldset, fieldset_options(options) do
         safe_join([
-          legend.html_safe,
-          choices.map do |choice|
-            label(attribute, class: 'block-label', value: choice) do |tag|
-              radio_button(attribute, choice) + localized_label("#{attribute}.#{choice}")
-            end
-          end
+          fieldset_legend(attribute),
+          radio_inputs(attribute, options)
         ], "\n")
       end
     end
 
     private
+
+    def radio_inputs attribute, options
+      choices = options[:choices] || [ :yes, :no ]
+      choices.map do |choice|
+        label(attribute, class: 'block-label', value: choice) do |tag|
+          input = radio_button(attribute, choice)
+          input + localized_label("#{attribute}.#{choice}")
+        end
+      end
+    end
+
+    def fieldset_legend attribute
+      legend = content_tag(:legend, fieldset_text(attribute), class: 'heading-medium')
+      add_hint :legend, legend, attribute
+      legend.html_safe
+    end
+
+    def fieldset_options options
+      fieldset_options = {}
+      fieldset_options[:class] = 'inline' if options[:inline] == true
+      fieldset_options
+    end
 
     def add_error_to_html_tag! html_tag
       case html_tag

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -11,6 +11,7 @@ class Person
   attr_accessor :password
   attr_accessor :password_confirmation
   attr_accessor :gender
+  attr_accessor :has_user_account
 
   attr_accessor :address
 

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -2,18 +2,17 @@ class Person
   include ActiveModel::Model
   GENDER = %w{ female male }
 
-  attr_accessor :name
-  validates_presence_of :name
-
-  attr_accessor :ni_number
+  attr_accessor :address
   attr_accessor :email_work
   attr_accessor :email_home
+  attr_accessor :has_user_account
+  attr_accessor :location
+  attr_accessor :name
+  attr_accessor :ni_number
   attr_accessor :password
   attr_accessor :password_confirmation
-  attr_accessor :gender
-  attr_accessor :has_user_account
 
-  attr_accessor :address
+  validates_presence_of :name
 
   def address_attributes=(attributes)
     @address = Address.new(attributes)

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -1,5 +1,6 @@
 class Person
   include ActiveModel::Model
+  GENDER = %w{ female male }
 
   attr_accessor :name
   validates_presence_of :name
@@ -9,6 +10,7 @@ class Person
   attr_accessor :email_home
   attr_accessor :password
   attr_accessor :password_confirmation
+  attr_accessor :gender
 
   attr_accessor :address
 

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -30,6 +30,9 @@ en:
         ni_number: National Insurance number
         password: Password
         password_confirmation: Confirm password
+        gender:
+          male: Male or identify as male
+          female: Female or identify as female
       person[address_attributes]:
         address: Full address
       person[address_attributes][country_attributes]:

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -22,6 +22,9 @@
 en:
   hello: "Hello world"
   helpers:
+    fieldset:
+      person:
+        gender: Specify gender identity
     label:
       person:
         email_home: Home email address

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -24,19 +24,20 @@ en:
   helpers:
     fieldset:
       person:
-        gender: Specify gender identity
+        location: Where do you live?
         has_user_account: Do you already have a personal user account?
     label:
       person:
         email_home: Home email address
         email_work: Work email address
+        location:
+          ni: Northern Ireland
+          isle_of_man_channel_islands: Isle of Man or Channel Islands
+          british_abroad: I am a British citizen living abroad
         name: Full name
         ni_number: National Insurance number
         password: Password
         password_confirmation: Confirm password
-        gender:
-          male: Male or identify as male
-          female: Female or identify as female
       person[address_attributes]:
         address: Full address
       person[address_attributes][country_attributes]:
@@ -44,8 +45,8 @@ en:
     hint:
       person:
         email_home: For eg. John.Smith@example.com
+        location: Select from these options because you answered you do not reside in England, Wales, or Scotland
         ni_number: It’ll be on your last payslip. For example, JH 21 90 0A.
         password_confirmation: Password should match
-        gender: If unknown at time of application choose unknown
       person[address_attributes]:
         address: Exclude postcode. For example, 102 Petty France, London

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -45,5 +45,6 @@ en:
         email_home: For eg. John.Smith@example.com
         ni_number: It’ll be on your last payslip. For example, JH 21 90 0A.
         password_confirmation: Password should match
+        gender: If unknown at time of application choose unknown
       person[address_attributes]:
         address: Exclude postcode. For example, 102 Petty France, London

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -25,6 +25,7 @@ en:
     fieldset:
       person:
         gender: Specify gender identity
+        has_user_account: Do you already have a personal user account?
     label:
       person:
         email_home: Home email address

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -222,14 +222,10 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     end
   end
 
-  describe '#radio_buttons' do
-    it 'outputs radio buttons and wrapped in labels' do
-      output = builder.collection_radio_buttons :gender, [["male", "male"] ,["female", "female"]], :first, :last
-
+  describe '#radio_button_fieldset' do
+    it 'outputs radio buttons wrapped in labels' do
+      output = builder.radio_button_fieldset :gender, 'Gender', choice: { 'male' => 'male', 'female' => 'female' }
       expect_equal output, [
-        '<h1 class="heading-medium">',
-        'Gender',
-        '</h1>',
         '<fieldset>',
         '<legend class="visuallyhidden">',
         'Gender',
@@ -246,22 +242,6 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       ]
     end
 
-    context 'when hint text provided' do
-      it 'outputs hint text in span inside label' do
-        output = builder.password_field :password_confirmation
-        expect_equal output, [
-          '<div class="form-group">',
-          '<label class="form-label" for="person_password_confirmation">',
-          'Confirm password',
-          '<span class="form-hint">',
-          'Password should match',
-          '</span>',
-          '</label>',
-          '<input class="form-control" type="password" name="person[password_confirmation]" id="person_password_confirmation" />',
-          '</div>'
-        ]
-      end
-    end
   end
 
 end

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -224,11 +224,11 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
   describe '#radio_button_fieldset' do
     it 'outputs radio buttons wrapped in labels' do
-      output = builder.radio_button_fieldset :gender, 'Gender', choices: [ :male, :female, :unknown ]
+      output = builder.radio_button_fieldset :gender, choices: [ :male, :female, :unknown ]
       expect_equal output, [
         '<fieldset>',
         '<legend class="visuallyhidden">',
-        'Gender',
+        'Specify gender identity',
         '</legend>',
         '<label class="block-label" for="person_gender_male">',
         '<input type="radio" value="male" name="person[gender]" id="person_gender_male" />',

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -222,4 +222,46 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     end
   end
 
+  describe '#radio_buttons' do
+    it 'outputs radio buttons and wrapped in labels' do
+      output = builder.collection_radio_buttons :gender, [["male", "male"] ,["female", "female"]], :first, :last
+
+      expect_equal output, [
+        '<h1 class="heading-medium">',
+        'Gender',
+        '</h1>',
+        '<fieldset>',
+        '<legend class="visuallyhidden">',
+        'Gender',
+        '</legend>',
+        '<label class="block-label" for="person_gender_male">',
+        '<input type="radio" value="male" name="person[gender]" id="person_gender_male" />',
+        'male',
+        '</label>',
+        '<label class="block-label" for="person_gender_female">',
+        '<input type="radio" value="female" name="person[gender]" id="person_gender_female" />',
+        'female',
+        '</label>',
+        '</fieldset>'
+      ]
+    end
+
+    context 'when hint text provided' do
+      it 'outputs hint text in span inside label' do
+        output = builder.password_field :password_confirmation
+        expect_equal output, [
+          '<div class="form-group">',
+          '<label class="form-label" for="person_password_confirmation">',
+          'Confirm password',
+          '<span class="form-hint">',
+          'Password should match',
+          '</span>',
+          '</label>',
+          '<input class="form-control" type="password" name="person[password_confirmation]" id="person_password_confirmation" />',
+          '</div>'
+        ]
+      end
+    end
+  end
+
 end

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -249,6 +249,25 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       ]
     end
 
+    it 'outputs yes/no choices when no choices specified, and adds "inline" class to fieldset when passed "inline: true"' do
+      output = builder.radio_button_fieldset :has_user_account, inline: true
+      expect_equal output, [
+        '<fieldset class="inline">',
+        '<legend class="heading-medium">',
+        'Do you already have a personal user account?',
+        '</legend>',
+        '<label class="block-label" for="person_has_user_account_yes">',
+        '<input type="radio" value="yes" name="person[has_user_account]" id="person_has_user_account_yes" />',
+        'Yes',
+        '</label>',
+        '<label class="block-label" for="person_has_user_account_no">',
+        '<input type="radio" value="no" name="person[has_user_account]" id="person_has_user_account_no" />',
+        'No',
+        '</label>',
+        '</fieldset>'
+      ]
+    end
+
   end
 
 end

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -224,26 +224,26 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
   describe '#radio_button_fieldset' do
     it 'outputs radio buttons wrapped in labels' do
-      output = builder.radio_button_fieldset :gender, choices: [ :male, :female, :unknown ]
+      output = builder.radio_button_fieldset :location, choices: [:ni, :isle_of_man_channel_islands, :british_abroad]
       expect_equal output, [
         '<fieldset>',
         '<legend class="heading-medium">',
-        'Specify gender identity',
+        'Where do you live?',
         '<span class="form-hint">',
-        'If unknown at time of application choose unknown',
+        'Select from these options because you answered you do not reside in England, Wales, or Scotland',
         '</span>',
         '</legend>',
-        '<label class="block-label" for="person_gender_male">',
-        '<input type="radio" value="male" name="person[gender]" id="person_gender_male" />',
-        'Male or identify as male',
+        '<label class="block-label" for="person_location_ni">',
+        '<input type="radio" value="ni" name="person[location]" id="person_location_ni" />',
+        'Northern Ireland',
         '</label>',
-        '<label class="block-label" for="person_gender_female">',
-        '<input type="radio" value="female" name="person[gender]" id="person_gender_female" />',
-        'Female or identify as female',
+        '<label class="block-label" for="person_location_isle_of_man_channel_islands">',
+        '<input type="radio" value="isle_of_man_channel_islands" name="person[location]" id="person_location_isle_of_man_channel_islands" />',
+        'Isle of Man or Channel Islands',
         '</label>',
-        '<label class="block-label" for="person_gender_unknown">',
-        '<input type="radio" value="unknown" name="person[gender]" id="person_gender_unknown" />',
-        'Unknown',
+        '<label class="block-label" for="person_location_british_abroad">',
+        '<input type="radio" value="british_abroad" name="person[location]" id="person_location_british_abroad" />',
+        'I am a British citizen living abroad',
         '</label>',
         '</fieldset>'
       ]

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
   describe '#radio_button_fieldset' do
     it 'outputs radio buttons wrapped in labels' do
-      output = builder.radio_button_fieldset :gender, 'Gender', choice: { 'male' => 'male', 'female' => 'female' }
+      output = builder.radio_button_fieldset :gender, 'Gender', choices: [ :male, :female, :unknown ]
       expect_equal output, [
         '<fieldset>',
         '<legend class="visuallyhidden">',
@@ -232,11 +232,15 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
         '</legend>',
         '<label class="block-label" for="person_gender_male">',
         '<input type="radio" value="male" name="person[gender]" id="person_gender_male" />',
-        'male',
+        'Male or identify as male',
         '</label>',
         '<label class="block-label" for="person_gender_female">',
         '<input type="radio" value="female" name="person[gender]" id="person_gender_female" />',
-        'female',
+        'Female or identify as female',
+        '</label>',
+        '<label class="block-label" for="person_gender_unknown">',
+        '<input type="radio" value="unknown" name="person[gender]" id="person_gender_unknown" />',
+        'Unknown',
         '</label>',
         '</fieldset>'
       ]

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -227,8 +227,11 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       output = builder.radio_button_fieldset :gender, choices: [ :male, :female, :unknown ]
       expect_equal output, [
         '<fieldset>',
-        '<legend class="visuallyhidden">',
+        '<legend class="heading-medium">',
         'Specify gender identity',
+        '<span class="form-hint">',
+        'If unknown at time of application choose unknown',
+        '</span>',
         '</legend>',
         '<label class="block-label" for="person_gender_male">',
         '<input type="radio" value="male" name="person[gender]" id="person_gender_male" />',


### PR DESCRIPTION
Add helper method to generate fieldsets containing radio buttons, based on the [GOV.UK elements radio buttons markup](https://govuk-elements.herokuapp.com/form-elements/#form-radio-buttons).

We deviated from GOV.UK elements markup by putting the question text in a visible legend element, and not in a h1 element.

Closes #17