### PR TITLE
Allow custom class attributes to be set on input fields

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -26,8 +26,7 @@ module GovukElementsFormBuilder
       define_method(method_name) do |attribute, *args|
         content_tag :div, class: form_group_classes(attribute), id: form_group_id(attribute) do
           options = args.extract_options!
-          text_field_class = ["form-control"]
-          options[:class] = text_field_class
+          set_field_classes! options
 
           label = label(attribute, class: "form-label")
           add_hint :label, label, attribute
@@ -55,6 +54,18 @@ module GovukElementsFormBuilder
     end
 
     private
+
+    def set_field_classes! options
+      text_field_class = "form-control"
+      options[:class] = case options[:class]
+                        when String
+                          [options[:class], text_field_class]
+                        when Array
+                          options[:class] << text_field_class
+                        else
+                          options[:class] = text_field_class
+                        end
+    end
 
     def check_box_inputs attributes
       attributes.map do |attribute|

--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -65,9 +65,9 @@ module GovukElementsFormBuilder
       text_field_class = "form-control"
       options[:class] = case options[:class]
                         when String
-                          [options[:class], text_field_class]
+                          [text_field_class, options[:class]]
                         when Array
-                          options[:class] << text_field_class
+                          options[:class].unshift text_field_class
                         else
                           options[:class] = text_field_class
                         end

--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -20,8 +20,14 @@ module GovukElementsFormBuilder
     %i[
       email_field
       password_field
+      number_field
+      phone_field
+      range_field
+      search_field
+      telephone_field
       text_area
       text_field
+      url_field
     ].each do |method_name|
       define_method(method_name) do |attribute, *args|
         content_tag :div, class: form_group_classes(attribute), id: form_group_id(attribute) do

--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -103,7 +103,9 @@ module GovukElementsFormBuilder
       when /^<label/
         add_error_to_label! html_tag
       when /^<input/
-        add_error_to_input! html_tag
+        add_error_to_input! html_tag, 'input'
+      when /^<textarea/
+        add_error_to_input! html_tag, 'textarea'
       else
         html_tag
       end
@@ -125,9 +127,9 @@ module GovukElementsFormBuilder
         %'<span class="error-message" id="error_message_#{field}">#{message}</span></label')
     end
 
-    def add_error_to_input! html_tag
+    def add_error_to_input! html_tag, element
       field = html_tag[/id="([^"]+)"/, 1]
-      html_tag.sub!('input', %'input aria-describedby="error_message_#{field}"')
+      html_tag.sub!(element, %'#{element} aria-describedby="error_message_#{field}"')
     end
 
     def form_group_classes attribute

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -200,8 +200,32 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     include_examples 'input field', :email_field, :email
   end
 
+  describe "#number_field" do
+    include_examples 'input field', :number_field, :number
+  end
+
   describe '#password_field' do
     include_examples 'input field', :password_field, :password
+  end
+
+  describe '#phone_field' do
+    include_examples 'input field', :phone_field, :tel
+  end
+
+  describe '#range_field' do
+    include_examples 'input field', :range_field, :range
+  end
+
+  describe '#search_field' do
+    include_examples 'input field', :search_field, :search
+  end
+
+  describe '#telephone_field' do
+    include_examples 'input field', :telephone_field, :tel
+  end
+
+  describe '#url_field' do
+    include_examples 'input field', :url_field, :url
   end
 
   describe '#radio_button_fieldset' do

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       it 'outputs label and input with correct ids' do
         resource.address = Address.new
         output = builder.fields_for(:address) do |f|
-          f.text_field :postcode
+          f.send method, :postcode
         end
         expect_equal output, [
           '<div class="form-group">',
@@ -203,65 +203,11 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
   end
 
   describe '#email_field' do
-    it 'outputs label and input wrapped in div' do
-      output = builder.email_field :email_work
-      expect_equal output, [
-        '<div class="form-group">',
-        '<label class="form-label" for="person_email_work">',
-        'Work email address',
-        '</label>',
-        '<input class="form-control" type="email" name="person[email_work]" id="person_email_work" />',
-        '</div>'
-      ]
-    end
-
-    context 'when hint text provided' do
-      it 'outputs hint text in span inside label' do
-        output = builder.email_field :email_home
-        expect_equal output, [
-          '<div class="form-group">',
-          '<label class="form-label" for="person_email_home">',
-          'Home email address',
-          '<span class="form-hint">',
-          'For eg. John.Smith@example.com',
-          '</span>',
-          '</label>',
-          '<input class="form-control" type="email" name="person[email_home]" id="person_email_home" />',
-          '</div>'
-        ]
-      end
-    end
+    include_examples 'input field', :email_field, :email
   end
 
   describe '#password_field' do
-    it 'outputs label and input wrapped in div' do
-      output = builder.password_field :password
-      expect_equal output, [
-        '<div class="form-group">',
-        '<label class="form-label" for="person_password">',
-        'Password',
-        '</label>',
-        '<input class="form-control" type="password" name="person[password]" id="person_password" />',
-        '</div>'
-      ]
-    end
-
-    context 'when hint text provided' do
-      it 'outputs hint text in span inside label' do
-        output = builder.password_field :password_confirmation
-        expect_equal output, [
-          '<div class="form-group">',
-          '<label class="form-label" for="person_password_confirmation">',
-          'Confirm password',
-          '<span class="form-hint">',
-          'Password should match',
-          '</span>',
-          '</label>',
-          '<input class="form-control" type="password" name="person[password_confirmation]" id="person_password_confirmation" />',
-          '</div>'
-        ]
-      end
-    end
+    include_examples 'input field', :password_field, :password
   end
 
   describe '#radio_button_fieldset' do

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -59,6 +59,18 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       ]
     end
 
+    it 'passes options passed to text_field onto super text_field implementation' do
+      output = builder.text_field :name, size: 100
+      expect_equal output, [
+        '<div class="form-group">',
+        '<label class="form-label" for="person_name">',
+        'Full name',
+        '</label>',
+        '<input size="100" class="form-control" type="text" name="person[name]" id="person_name" />',
+        '</div>'
+      ]
+    end
+
     context 'when hint text provided' do
       it 'outputs hint text in span inside label' do
         output = builder.text_field :ni_number

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -47,27 +47,27 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     end
 
     it 'adds custom class to input when passed class: "custom-class"' do
-      output = builder.send method, :name, class: "custom-class"
+      output = builder.send method, :name, class: 'custom-class'
 
       expect_equal output, [
         '<div class="form-group">',
         '<label class="form-label" for="person_name">',
         'Full name',
         '</label>',
-        %'<#{element_for(method)} class="custom-class form-control" #{type_for(method, type)}name="person[name]" id="person_name" />',
+        %'<#{element_for(method)} class="form-control custom-class" #{type_for(method, type)}name="person[name]" id="person_name" />',
         '</div>'
       ]
     end
 
     it 'adds custom classes to input when passed class: ["custom-class", "another-class"]' do
-      output = builder.send method, :name, class: ["custom-class", "another-class"]
+      output = builder.send method, :name, class: ['custom-class', 'another-class']
 
       expect_equal output, [
         '<div class="form-group">',
         '<label class="form-label" for="person_name">',
         'Full name',
         '</label>',
-        %'<#{element_for(method)} class="custom-class another-class form-control" #{type_for(method, type)}name="person[name]" id="person_name" />',
+        %'<#{element_for(method)} class="form-control custom-class another-class" #{type_for(method, type)}name="person[name]" id="person_name" />',
         '</div>'
       ]
     end

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -33,6 +33,32 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       ]
     end
 
+    it 'adds custom class to input when passed class: "custom-class"' do
+      output = builder.text_field :name, class: "custom-class"
+
+      expect_equal output, [
+        '<div class="form-group">',
+        '<label class="form-label" for="person_name">',
+        'Full name',
+        '</label>',
+        '<input class="custom-class form-control" type="text" name="person[name]" id="person_name" />',
+        '</div>'
+      ]
+    end
+
+    it 'adds custom classes to input when passed class: ["custom-class", "another-class"]' do
+      output = builder.text_field :name, class: ["custom-class", "another-class"]
+
+      expect_equal output, [
+        '<div class="form-group">',
+        '<label class="form-label" for="person_name">',
+        'Full name',
+        '</label>',
+        '<input class="custom-class another-class form-control" type="text" name="person[name]" id="person_name" />',
+        '</div>'
+      ]
+    end
+
     context 'when hint text provided' do
       it 'outputs hint text in span inside label' do
         output = builder.text_field :ni_number

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -19,61 +19,61 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     expect(split_output).to eq split_expected
   end
 
-  describe '#text_field' do
+  shared_examples_for 'input field' do |method, type|
     it 'outputs label and input wrapped in div' do
-      output = builder.text_field :name
+      output = builder.send method, :name
 
       expect_equal output, [
         '<div class="form-group">',
         '<label class="form-label" for="person_name">',
         'Full name',
         '</label>',
-        '<input class="form-control" type="text" name="person[name]" id="person_name" />',
+        %'<input class="form-control" type="#{type}" name="person[name]" id="person_name" />',
         '</div>'
       ]
     end
 
     it 'adds custom class to input when passed class: "custom-class"' do
-      output = builder.text_field :name, class: "custom-class"
+      output = builder.send method, :name, class: "custom-class"
 
       expect_equal output, [
         '<div class="form-group">',
         '<label class="form-label" for="person_name">',
         'Full name',
         '</label>',
-        '<input class="custom-class form-control" type="text" name="person[name]" id="person_name" />',
+        %'<input class="custom-class form-control" type="#{type}" name="person[name]" id="person_name" />',
         '</div>'
       ]
     end
 
     it 'adds custom classes to input when passed class: ["custom-class", "another-class"]' do
-      output = builder.text_field :name, class: ["custom-class", "another-class"]
+      output = builder.send method, :name, class: ["custom-class", "another-class"]
 
       expect_equal output, [
         '<div class="form-group">',
         '<label class="form-label" for="person_name">',
         'Full name',
         '</label>',
-        '<input class="custom-class another-class form-control" type="text" name="person[name]" id="person_name" />',
+        %'<input class="custom-class another-class form-control" type="#{type}" name="person[name]" id="person_name" />',
         '</div>'
       ]
     end
 
     it 'passes options passed to text_field onto super text_field implementation' do
-      output = builder.text_field :name, size: 100
+      output = builder.send method, :name, size: 100
       expect_equal output, [
         '<div class="form-group">',
         '<label class="form-label" for="person_name">',
         'Full name',
         '</label>',
-        '<input size="100" class="form-control" type="text" name="person[name]" id="person_name" />',
+        %'<input size="100" class="form-control" type="#{type}" name="person[name]" id="person_name" />',
         '</div>'
       ]
     end
 
     context 'when hint text provided' do
       it 'outputs hint text in span inside label' do
-        output = builder.text_field :ni_number
+        output = builder.send method, :ni_number
         expect_equal output, [
           '<div class="form-group">',
           '<label class="form-label" for="person_ni_number">',
@@ -82,7 +82,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
           'It’ll be on your last payslip. For example, JH 21 90 0A.',
           '</span>',
           '</label>',
-          '<input class="form-control" type="text" name="person[ni_number]" id="person_ni_number" />',
+          %'<input class="form-control" type="#{type}" name="person[ni_number]" id="person_ni_number" />',
           '</div>'
         ]
       end
@@ -99,7 +99,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
           '<label class="form-label" for="person_address_attributes_postcode">',
           'Postcode',
           '</label>',
-          '<input class="form-control" type="text" name="person[address_attributes][postcode]" id="person_address_attributes_postcode" />',
+          %'<input class="form-control" type="#{type}" name="person[address_attributes][postcode]" id="person_address_attributes_postcode" />',
           '</div>'
         ]
       end
@@ -108,7 +108,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     context 'when validation error on object' do
       it 'outputs error message in span inside label' do
         resource.valid?
-        output = builder.text_field :name
+        output = builder.send method, :name
 
         expect_equal output, [
           '<div class="form-group error" id="error_person_name">',
@@ -118,7 +118,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
           "Full name is required",
           '</span>',
           '</label>',
-          '<input aria-describedby="error_message_person_name" class="form-control" type="text" name="person[name]" id="person_name" />',
+          %'<input aria-describedby="error_message_person_name" class="form-control" type="#{type}" name="person[name]" id="person_name" />',
           '</div>'
         ]
       end
@@ -130,7 +130,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
         resource.address.valid?
 
         output = builder.fields_for(:address) do |f|
-          f.text_field :postcode
+          f.send method, :postcode
         end
 
         expect_equal output, [
@@ -141,7 +141,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
           "Postcode is required",
           '</span>',
           '</label>',
-          '<input aria-describedby="error_message_person_address_attributes_postcode" class="form-control" type="text" name="person[address_attributes][postcode]" id="person_address_attributes_postcode" />',
+          %'<input aria-describedby="error_message_person_address_attributes_postcode" class="form-control" type="#{type}" name="person[address_attributes][postcode]" id="person_address_attributes_postcode" />',
           '</div>'
         ]
       end
@@ -155,7 +155,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
         output = builder.fields_for(:address) do |address|
           address.fields_for(:country) do |country|
-            country.text_field :name
+            country.send method, :name
           end
         end
 
@@ -167,12 +167,16 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
           "Country is required",
           '</span>',
           '</label>',
-          '<input aria-describedby="error_message_person_address_attributes_country_attributes_name" class="form-control" type="text" name="person[address_attributes][country_attributes][name]" id="person_address_attributes_country_attributes_name" />',
+          %'<input aria-describedby="error_message_person_address_attributes_country_attributes_name" class="form-control" type="#{type}" name="person[address_attributes][country_attributes][name]" id="person_address_attributes_country_attributes_name" />',
           '</div>'
         ]
       end
     end
 
+  end
+
+  describe '#text_field' do
+    include_examples 'input field', :text_field, :text
   end
 
   describe '#text_area' do


### PR DESCRIPTION
- Allow custom classes to be set on `text_field` input.
- Spec options passed to `text_field` are passed on to super implementation.
- Extract input field specs into shared examples.
- Use input field shared examples to test `#email_field` and `#password_field`.
- Use input field shared examples to test `#text_area`.