### PR TITLE
Spec error messages follow errors.format formatting

### DIFF
--- a/spec/helpers/govuk_elements_errors_helper_spec.rb
+++ b/spec/helpers/govuk_elements_errors_helper_spec.rb
@@ -10,31 +10,8 @@ RSpec.describe GovukElementsErrorsHelper, type: :helper do
     output.split('>').join(">\n")
   end
 
-  describe '#error_summary when object has validation errors' do
+  shared_examples_for 'error summary' do |message, attribute|
     it 'outputs error full messages' do
-      resource.valid?
-      output = described_class.error_summary resource, error_summary_heading, error_summary_description
-      expect(split_html(output)).to eq split_html('<div ' +
-          'class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">' +
-        '<h1 id="error-summary-heading" class="heading-medium error-summary-heading">' +
-          error_summary_heading +
-        '</h1>' +
-        '<p>' +
-          error_summary_description +
-        '</p>' +
-        '<ul class="error-summary-list">' +
-          '<li><a href="#error_person_name">Full name is required</a></li>' +
-        '</ul>' +
-      '</div>')
-    end
-  end
-
-  describe '#error_summary when child object has validation errors' do
-    it 'outputs error full messages of child object' do
-      resource.address = Address.new
-      resource.address.valid?
-
-      output = described_class.error_summary resource, error_summary_heading, error_summary_description
       expect(output).to_not be_nil
       expect(split_html(output)).to eq split_html('<div ' +
           'class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">' +
@@ -45,33 +22,42 @@ RSpec.describe GovukElementsErrorsHelper, type: :helper do
           error_summary_description +
         '</p>' +
         '<ul class="error-summary-list">' +
-          '<li><a href="#error_person_address_attributes_postcode">Postcode is required</a></li>' +
+          %'<li><a href="#error_#{attribute}">#{message}</a></li>' +
         '</ul>' +
       '</div>')
     end
   end
 
+  describe '#error_summary when object has validation errors' do
+    let(:output) do
+      resource.valid?
+      described_class.error_summary resource, error_summary_heading, error_summary_description
+    end
+
+    include_examples 'error summary', 'Full name is required', 'person_name'
+  end
+
+  describe '#error_summary when child object has validation errors' do
+    let(:output) do
+      resource.address = Address.new
+      resource.address.valid?
+
+      described_class.error_summary resource, error_summary_heading, error_summary_description
+    end
+
+    include_examples 'error summary', 'Postcode is required', 'person_address_attributes_postcode'
+  end
+
   describe '#error_summary when twice nested child object has validation errors' do
-    it 'outputs error full messages of child object' do
+    let(:output) do
       resource.address = Address.new
       resource.address.country = Country.new
       resource.address.country.valid?
 
-      output = described_class.error_summary resource, error_summary_heading, error_summary_description
-      expect(output).to_not be_nil
-      expect(split_html(output)).to eq split_html('<div ' +
-          'class="error-summary" role="group" aria-labelledby="error-summary-heading" tabindex="-1">' +
-        '<h1 id="error-summary-heading" class="heading-medium error-summary-heading">' +
-          error_summary_heading +
-        '</h1>' +
-        '<p>' +
-          error_summary_description +
-        '</p>' +
-        '<ul class="error-summary-list">' +
-          '<li><a href="#error_person_address_attributes_country_attributes_name">Country is required</a></li>' +
-        '</ul>' +
-      '</div>')
+      described_class.error_summary resource, error_summary_heading, error_summary_description
     end
+
+    include_examples 'error summary', 'Country is required', 'person_address_attributes_country_attributes_name'
   end
 
   describe '#error_summary when object does not have validation errors' do

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 class TestHelper < ActionView::Base; end
 
 RSpec.describe GovukElementsFormBuilder::FormBuilder do
+  include TranslationHelper
 
   it "should have a version" do
     expect(GovukElementsFormBuilder::VERSION).to eq("0.0.1")
@@ -125,6 +126,27 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
         expected = expected_error_html method, type, 'person_name',
           'person[name]', 'Full name', 'Full name is required'
         expect_equal output, expected
+      end
+
+      it 'outputs custom error message format in span inside label' do
+        translations = YAML.load(%'
+            errors:
+              format: "%{message}"
+            activemodel:
+              errors:
+                models:
+                  person:
+                    attributes:
+                      name:
+                        blank: "Enter your full name"
+        ')
+        with_translations(:en, translations) do
+          resource.valid?
+          output = builder.send method, :name
+          expected = expected_error_html method, type, 'person_name',
+            'person[name]', 'Name', 'Enter your full name'
+          expect_equal output, expected
+        end
       end
     end
 

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -122,18 +122,9 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       it 'outputs error message in span inside label' do
         resource.valid?
         output = builder.send method, :name
-
-        expect_equal output, [
-          '<div class="form-group error" id="error_person_name">',
-          '<label class="form-label" for="person_name">',
-          'Full name',
-          '<span class="error-message" id="error_message_person_name">',
-          "Full name is required",
-          '</span>',
-          '</label>',
-          %'<#{element_for(method)} aria-describedby="error_message_person_name" class="form-control" #{type_for(method, type)}name="person[name]" id="person_name" />',
-          '</div>'
-        ]
+        expected = expected_error_html method, type, 'person_name',
+          'person[name]', 'Full name', 'Full name is required'
+        expect_equal output, expected
       end
     end
 
@@ -146,17 +137,9 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
           f.send method, :postcode
         end
 
-        expect_equal output, [
-          '<div class="form-group error" id="error_person_address_attributes_postcode">',
-          '<label class="form-label" for="person_address_attributes_postcode">',
-          'Postcode',
-          '<span class="error-message" id="error_message_person_address_attributes_postcode">',
-          "Postcode is required",
-          '</span>',
-          '</label>',
-          %'<#{element_for(method)} aria-describedby="error_message_person_address_attributes_postcode" class="form-control" #{type_for(method, type)}name="person[address_attributes][postcode]" id="person_address_attributes_postcode" />',
-          '</div>'
-        ]
+        expected = expected_error_html method, type, 'person_address_attributes_postcode',
+          'person[address_attributes][postcode]', 'Postcode', 'Postcode is required'
+        expect_equal output, expected
       end
     end
 
@@ -172,20 +155,26 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
           end
         end
 
-        expect_equal output, [
-          '<div class="form-group error" id="error_person_address_attributes_country_attributes_name">',
-          '<label class="form-label" for="person_address_attributes_country_attributes_name">',
-          'Country',
-          '<span class="error-message" id="error_message_person_address_attributes_country_attributes_name">',
-          "Country is required",
-          '</span>',
-          '</label>',
-          %'<#{element_for(method)} aria-describedby="error_message_person_address_attributes_country_attributes_name" class="form-control" #{type_for(method, type)}name="person[address_attributes][country_attributes][name]" id="person_address_attributes_country_attributes_name" />',
-          '</div>'
-        ]
+        expected = expected_error_html method, type, 'person_address_attributes_country_attributes_name',
+          'person[address_attributes][country_attributes][name]', 'Country', 'Country is required'
+        expect_equal output, expected
       end
     end
 
+  end
+
+  def expected_error_html method, type, attribute, name_value, label, error
+    [
+      %'<div class="form-group error" id="error_#{attribute}">',
+      %'<label class="form-label" for="#{attribute}">',
+      label,
+      %'<span class="error-message" id="error_message_#{attribute}">',
+      error,
+      '</span>',
+      '</label>',
+      %'<#{element_for(method)} aria-describedby="error_message_#{attribute}" class="form-control" #{type_for(method, type)}name="#{name_value}" id="#{attribute}" />',
+      '</div>'
+    ]
   end
 
   describe '#text_field' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,6 +20,7 @@ require 'byebug'
 # require only the support files necessary.
 #
 # Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+require_relative 'support/translation_helper.rb'
 
 # Checks for pending migrations before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/support/translation_helper.rb
+++ b/spec/support/translation_helper.rb
@@ -1,0 +1,12 @@
+module TranslationHelper
+  def with_translations(locale, translations)
+    original_backend = I18n.backend
+
+    I18n.backend = I18n::Backend::KeyValue.new Hash.new, true
+    I18n.backend.store_translations locale, translations
+
+    yield
+  ensure
+    I18n.backend = original_backend
+  end
+end


### PR DESCRIPTION
When `errors.format` is set in the locales file:
- Spec that `#error_summary` outputs error messages that comply with the custom errors format.
- Spec that form builder helpers add validation error messages that comply with the custom errors format.

Closes #46
