### PR TITLE
Relax Rails version requirement to include > 4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     govuk_elements_form_builder (0.0.1)
-      rails (~> 4.2)
+      rails (>= 4.2)
 
 GEM
   remote: https://rubygems.org/
@@ -46,7 +46,7 @@ GEM
     builder (3.2.2)
     byebug (8.2.0)
     coderay (1.1.1)
-    concurrent-ruby (1.0.1)
+    concurrent-ruby (1.0.2)
     diff-lcs (1.2.5)
     erubis (2.7.0)
     ffi (1.9.10)
@@ -147,7 +147,7 @@ GEM
     rspec-support (3.2.2)
     shellany (0.0.1)
     slop (3.6.0)
-    sprockets (3.5.2)
+    sprockets (3.6.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.0.4)
@@ -171,4 +171,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.11.2
+   1.12.3

--- a/govuk_elements_form_builder.gemspec
+++ b/govuk_elements_form_builder.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
-  s.add_dependency "rails", "~> 4.2"
+  s.add_dependency "rails", ">= 4.2"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"


### PR DESCRIPTION
Gem seems to work fine on 5.0 RC1 – I think we can relax the Rails version requirement to be less specific.