### PR TITLE
Use the same signature in 'fields_for'

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -12,9 +12,8 @@ module GovukElementsFormBuilder
     end
 
     # Ensure fields_for yields a GovukElementsFormBuilder.
-    def fields_for attribute, *args
-      options = args.extract_options!
-      super attribute, options.merge(builder: self.class)
+    def fields_for record_name, record_object = nil, fields_options = {}, &block
+      super record_name, record_object, fields_options.merge(builder: self.class), &block
     end
 
     %i[

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -104,8 +104,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
     context 'when fields_for used' do
       it 'outputs label and input with correct ids' do
-        resource.address = Address.new
-        output = builder.fields_for(:address) do |f|
+        output = builder.fields_for(:address, Address.new) do |f|
           f.send method, :postcode
         end
         expect_equal output, [


### PR DESCRIPTION
Fixes one of the allowed parameter combinations for `fields_for` method. The
combination that this fixes is when you pass the attribute name, and the
object, ie:

```ruby
fields_for(:attribute, nested_object) { |f| ...}
```

Before this fix the method renders nothing as the `record_object` as defined in
the original Rails implementation gets lost in the gem version. I've made the
method signature the same as the Rails version while preserving the previous
functionality of setting the builder in the options.