### PR TITLE
Failing test case for nested buiders nil error

### DIFF
--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -182,6 +182,25 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       end
     end
 
+    context 'when mixing the rendering order of nested builders' do
+      it 'outputs error messages in span inside label' do
+        resource.address = Address.new
+        resource.address.valid?
+        resource.valid?
+
+        # Render the postcode first
+        builder.fields_for(:address) do |address|
+          address.send method, :postcode
+        end
+
+        output = builder.send method, :name
+
+
+        expected = expected_error_html method, type, 'person_name',
+          'person[name]', 'Full name', 'Full name is required'
+        expect_equal output, expected
+      end
+    end
   end
 
   def expected_error_html method, type, attribute, name_value, label, error


### PR DESCRIPTION
When there is a nested builder that renders errors before the parent builder the
parent builder raises a nil error.

I believe the issue is because the initializer is not thread safe since it
overrides `ActionView::Base.field_error_proc` with a proc that is coupled with
form resource.

I think this might be a much bigger issue for applications served with threaded
servers such as Puma because requests from different people will override
`field_error_proc` with potentially strange results such as rendering forms from
different people or erroring randomly. Since Rails 5 Puma is also the default
webserver.