### PR TITLE
Fix non thread safe setting of ActionView::Base.field_error_proc

### DIFF
--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -21,15 +21,15 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     expect(split_output).to eq split_expected
   end
 
+  def element_for(method)
+    method == :text_area ? 'textarea' : 'input'
+  end
+
+  def type_for(method, type)
+    method == :text_area ? '' : %'type="#{type}" '
+  end
+
   shared_examples_for 'input field' do |method, type|
-
-    def element_for(method)
-      method == :text_area ? 'textarea' : 'input'
-    end
-
-    def type_for(method, type)
-      method == :text_area ? '' : %'type="#{type}" '
-    end
 
     def size(method, size)
       method == :text_area ? '' : %'size="#{size}" '
@@ -183,24 +183,25 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       end
     end
 
-    context 'when mixing the rendering order of nested builders' do
-      it 'outputs error messages in span inside label' do
-        resource.address = Address.new
-        resource.address.valid?
-        resource.valid?
+  end
 
-        # Render the postcode first
-        builder.fields_for(:address) do |address|
-          address.send method, :postcode
-        end
+  context 'when mixing the rendering order of nested builders' do
+    let(:method) { :text_field }
+    let(:type) { :text }
+    it 'outputs error messages in span inside label' do
+      resource.address = Address.new
+      resource.address.valid?
+      resource.valid?
 
-        output = builder.send method, :name
-
-
-        expected = expected_error_html method, type, 'person_name',
-          'person[name]', 'Full name', 'Full name is required'
-        expect_equal output, expected
+      # Render the postcode first
+      builder.fields_for(:address) do |address|
+        address.text_field :postcode
       end
+      output = builder.text_field :name
+
+      expected = expected_error_html :text_field, :text, 'person_name',
+        'person[name]', 'Full name', 'Full name is required'
+      expect_equal output, expected
     end
   end
 

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -183,6 +183,25 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       end
     end
 
+    context 'when mixing the rendering order of nested builders' do
+      it 'outputs error messages in span inside label' do
+        resource.address = Address.new
+        resource.address.valid?
+        resource.valid?
+
+        # Render the postcode first
+        builder.fields_for(:address) do |address|
+          address.send method, :postcode
+        end
+
+        output = builder.send method, :name
+
+
+        expected = expected_error_html method, type, 'person_name',
+          'person[name]', 'Full name', 'Full name is required'
+        expect_equal output, expected
+      end
+    end
   end
 
   def expected_error_html method, type, attribute, name_value, label, error


### PR DESCRIPTION
Call class method in proc set as `ActionView::Base.field_error_proc`, instead of a builder instance method. No longer set `ActionView::Base.field_error_proc` in builder initializer method.

Fixes nil exception raised when a nested builder renders errors before the  parent builder, reported by @alan.

Removes potential for threaded servers to override `ActionView::Base.field_error_proc` from multiple threads during concurrent request handling, which could cause inconsistent error rendering.

Change `add_error_to_html_tag!` and methods it calls to class methods. Where needed create builder instance methods with same name as class methods for instance usage.
