### PR TITLE
Allow specifying a CSS class for fieldset legend

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -43,7 +43,7 @@ module GovukElementsFormBuilder
                   id: form_group_id(attribute) do
         content_tag :fieldset, fieldset_options(attribute, options) do
           safe_join([
-                      fieldset_legend(attribute),
+                      fieldset_legend(attribute, legend_class: options[:legend_class]),
                       radio_inputs(attribute, options)
                     ], "\n")
         end
@@ -56,7 +56,7 @@ module GovukElementsFormBuilder
                   id: form_group_id(attributes) do
         content_tag :fieldset, fieldset_options(attributes, options) do
           safe_join([
-                      fieldset_legend(legend_key),
+                      fieldset_legend(legend_key, legend_class: options[:legend_class]),
                       check_box_inputs(attributes)
                     ], "\n")
         end
@@ -111,8 +111,10 @@ module GovukElementsFormBuilder
       end
     end
 
-    def fieldset_legend attribute
-      legend = content_tag(:legend) do
+    def fieldset_legend attribute, options = {}
+      legend_class = options[:legend_class]
+
+      legend = content_tag(:legend, class: legend_class) do
         tags = [content_tag(
                   :span,
                   fieldset_text(attribute),

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -292,6 +292,29 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     end
 
     it 'outputs yes/no choices when no choices specified, and adds "inline" class to fieldset when passed "inline: true"' do
+      output = builder.radio_button_fieldset :has_user_account, inline: true, legend_class: 'visuallyhidden'
+      expect_equal output, [
+        '<div class="form-group">',
+        '<fieldset class="inline">',
+        '<legend class="visuallyhidden">',
+        '<span class="form-label-bold">',
+        'Do you already have a personal user account?',
+        '</span>',
+        '</legend>',
+        '<label class="block-label" for="person_has_user_account_yes">',
+        '<input type="radio" value="yes" name="person[has_user_account]" id="person_has_user_account_yes" />',
+        'Yes',
+        '</label>',
+        '<label class="block-label" for="person_has_user_account_no">',
+        '<input type="radio" value="no" name="person[has_user_account]" id="person_has_user_account_no" />',
+        'No',
+        '</label>',
+        '</fieldset>',
+        '</div>'
+      ]
+    end
+
+    it 'allows specifying a class for the legend' do
       output = builder.radio_button_fieldset :has_user_account, inline: true
       expect_equal output, [
         '<div class="form-group">',
@@ -378,6 +401,33 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
         '<input name="person[waste_transport_attributes][farm_agricultural]" type="hidden" value="0" />',
         '<input type="checkbox" value="1" name="person[waste_transport_attributes][farm_agricultural]" id="person_waste_transport_attributes_farm_agricultural" />',
         'Farm or agricultural waste',
+        '</label>',
+        '</fieldset>',
+        '</div>'
+      ]
+    end
+
+    it 'allows specifying a class for the legend' do
+      resource.waste_transport = WasteTransport.new
+      output = builder.fields_for(:waste_transport) do |f|
+        f.check_box_fieldset :waste_transport, [:animal_carcasses], legend_class: 'visuallyhidden'
+      end
+
+      expect_equal output, [
+        '<div class="form-group">',
+        '<fieldset>',
+        '<legend class="visuallyhidden">',
+        '<span class="form-label-bold">',
+        'Which types of waste do you transport regularly?',
+        '</span>',
+        '<span class="form-hint">',
+        'Select all that apply',
+        '</span>',
+        '</legend>',
+        '<label class="block-label" for="person_waste_transport_attributes_animal_carcasses">',
+        '<input name="person[waste_transport_attributes][animal_carcasses]" type="hidden" value="0" />',
+        '<input type="checkbox" value="1" name="person[waste_transport_attributes][animal_carcasses]" id="person_waste_transport_attributes_animal_carcasses" />',
+        'Waste from animal carcasses',
         '</label>',
         '</fieldset>',
         '</div>'


### PR DESCRIPTION
A [common pattern](https://www.gov.uk/service-manual/user-centred-design/resources/patterns/question-pages.html) for simple question pages with a single fieldset is to hide the legend using CSS so as to avoid duplication (the question will already have been asked in an `<hX>` tag) but still allow screenreaders to access it.

This change allows the user to specify an HTML class attribute on the legend to do this (or indeed something else).