### PR TITLE
Assume translations are HTML safe

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -252,7 +252,7 @@ module GovukElementsFormBuilder
       key = "#{object_name}.#{attribute}"
       I18n.t(key,
         default: default,
-        scope: scope).presence
+        scope: scope).html_safe.presence
     end
 
     def localized scope, attribute, default


### PR DESCRIPTION
It's a common pattern on some applications to use (limited) HTML markup inside labels. This ensures translation calls are marked as html_safe.

![screen shot 2016-10-27 at 11 28 25](https://cloud.githubusercontent.com/assets/72141/19763921/40629f2e-9c38-11e6-982a-90cca8d3aba4.png)
