### PR TITLE
Change convention to localise radio input choices

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -106,7 +106,7 @@ module GovukElementsFormBuilder
       choices.map do |choice|
         label(attribute, class: 'block-label', value: choice) do |tag|
           input = radio_button(attribute, choice)
-          input + localized_label("#{attribute}.#{choice}")
+          input + localized_label("#{attribute}_choices.#{choice}")
         end
       end
     end

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -35,7 +35,7 @@ en:
       person:
         email_home: Home email address
         email_work: Work email address
-        location:
+        location_choices:
           ni: Northern Ireland
           isle_of_man_channel_islands: Isle of Man or Channel Islands
           british_abroad: I am a British citizen living abroad

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -419,7 +419,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       expect_equal output, [
           '<div class="form-group">',
           '<label class="form-label" for="person_location">',
-          '{:ni=&gt;&quot;Northern Ireland&quot;, :isle_of_man_channel_islands=&gt;&quot;Isle of Man or Channel Islands&quot;, :british_abroad=&gt;&quot;I am a British citizen living abroad&quot;}',
+          'Location',
           %'<span class="form-hint">',
           'Select from these options because you answered you do not reside in England, Wales, or Scotland',
           %'</span>',


### PR DESCRIPTION
Solves https://github.com/ministryofjustice/govuk_elements_form_builder/issues/63

This allows us to be able to configure both the locale for the attribute label and the labels for each of the choices, e.g:

```yaml
en:
  helpers:
    label:
      person:
        location: Location Label
        location_choices:
          ni: Northern Ireland
          isle_of_man_channel_islands: Isle of Man or Channel Islands
          british_abroad: I am a British citizen living abroad
```

Whereas before it was not possible to do this as the `location` key was being used to define the list of choices, so we could not define the actual label for the `location` attribute itself.