### PR TITLE
Support attributes defined as a string

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -192,9 +192,8 @@ module GovukElementsFormBuilder
     end
 
     def form_group_classes attributes
-      attributes = [attributes] if !attributes.respond_to? :count
       classes = 'form-group'
-      classes += ' error' if attributes.find { |a| error_for? a }
+      classes += ' error' if Array(attributes).find { |a| error_for? a }
       classes
     end
 

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
   let(:helper) { TestHelper.new }
   let(:resource)  { Person.new }
-  let(:builder) { described_class.new :person, resource, helper, {} }
+  subject(:builder) { described_class.new :person, resource, helper, {} }
 
   def expect_equal output, expected
     split_output = output.gsub(">\n</textarea>", ' />').split("<").join("\n<").split(">").join(">\n").squeeze("\n").strip + '>'
@@ -44,6 +44,19 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
         'Full name',
         '</label>',
         %'<#{element_for(method)} class="form-control" #{type_for(method, type)}name="person[name]" id="person_name" />',
+        '</div>'
+      ]
+    end
+
+    it 'supports attributes defined as a string' do
+      output = builder.send method, 'name', class: 'custom-class'
+
+      expect_equal output, [
+        '<div class="form-group">',
+        '<label class="form-label" for="person_name">',
+        'Full name',
+        '</label>',
+        %'<#{element_for(method)} class="form-control custom-class" #{type_for(method, type)}name="person[name]" id="person_name" />',
         '</div>'
       ]
     end
@@ -224,7 +237,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
   end
 
   describe '#text_area' do
-    include_examples 'input field', :text_area, nil
+    include_examples 'input field', :text_area
   end
 
   describe '#email_field' do


### PR DESCRIPTION
Solves https://github.com/ministryofjustice/govuk_elements_form_builder/issues/68

This fix ensures that any element passed to the method is correctly converted to an array:

```ruby
irb(main):001:0> Array([])
=> []
irb(main):002:0> Array(1)
=> [1]
irb(main):003:0> Array(nil)
=> []
irb(main):004:0> Array('string')
=> ["string"]
irb(main):005:0> Array(:symbol)
=> [:symbol]
irb(main):006:0> Array(['string', :symbol])
=> ["string", :symbol]
```