### PR TITLE
Enable use with unpersisted objects

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -208,7 +208,9 @@ module GovukElementsFormBuilder
     end
 
     def error_for? attribute
-      errors.messages.key?(attribute) && !errors.messages[attribute].empty?
+      object.respond_to?(:errors) &&
+      errors.messages.key?(attribute) &&
+      !errors.messages[attribute].empty?
     end
 
     private_class_method def self.object_attribute_for field, object_name

--- a/spec/dummy/app/models/report.rb
+++ b/spec/dummy/app/models/report.rb
@@ -1,0 +1,8 @@
+class Report
+
+  attr_accessor :name, :problem, :email
+
+  def persisted?
+    false
+  end
+end

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -103,6 +103,14 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       end
     end
 
+    context 'when resource is a not a persisted model' do
+      let(:resource) { Report.new }
+      let(:builder) { described_class.new :report, resource, helper, {} }
+      it "##{method} does not fail" do
+        expect { builder.send method, :name }.not_to raise_error
+      end
+    end
+
     context 'when validation error on object' do
       it 'outputs error message in span inside label' do
         resource.valid?


### PR DESCRIPTION
Handle NoMethodError when calling .errors method.
Using the form builder with an unpersisted object
(e.g. a problem report submitter) raises this error
since the object does not respond to .errors