### PR TITLE
Prevent infinite loop when recursing children that have parent as instance variable

### DIFF
--- a/app/helpers/govuk_elements_errors_helper.rb
+++ b/app/helpers/govuk_elements_errors_helper.rb
@@ -35,10 +35,13 @@ module GovukElementsErrorsHelper
       compact
   end
 
-  def self.child_to_parent object, parents={}
+  def self.child_to_parent object, parents={}, parent_object=nil
+    return parents if object == parent_object
+    parent_object ||= object
+
     attribute_objects(object).each do |child|
       parents[child] = object
-      child_to_parent child, parents
+      child_to_parent child, parents, parent_object
     end
     parents
   end

--- a/app/helpers/govuk_elements_errors_helper.rb
+++ b/app/helpers/govuk_elements_errors_helper.rb
@@ -131,8 +131,8 @@ module GovukElementsErrorsHelper
   def self.parents_list object, child_to_parents
     if parent = child_to_parents[object]
       [].tap do |parents|
-        while parent
-          parents.unshift parent
+        while parent && !parents.include?(parent)
+          parents.unshift parent # prepends parent to front of parents
           parent = child_to_parents[parent]
         end
       end

--- a/app/helpers/govuk_elements_errors_helper.rb
+++ b/app/helpers/govuk_elements_errors_helper.rb
@@ -38,22 +38,34 @@ module GovukElementsErrorsHelper
       compact
   end
 
-  def self.child_to_parent object, parents={}, parent_object=nil
-    return parents if object == parent_object
+  def self.array_to_parent list, object, child_to_parents={}, parent_object
+    list.each do |child|
+      child_to_parents[child] = object
+      child_to_parent child, child_to_parents, parent_object
+    end
+  end
+
+  def self.child_to_parent object, child_to_parents={}, parent_object=nil
+    return child_to_parents if object == parent_object
     parent_object ||= object
 
     attribute_objects(object).each do |child|
-      parents[child] = object
-      child_to_parent child, parents, parent_object
+      if child.is_a?(Array)
+        array_to_parent(child, object, child_to_parents, parent_object)
+      else
+        child_to_parents[child] = object
+        child_to_parent child, child_to_parents, parent_object
+      end
     end
-    parents
+
+    child_to_parents
   end
 
   def self.instance_variable object, var
     field = var.to_s.sub('@','').to_sym
     if object.respond_to?(field)
       child = object.send(field)
-      if respond_to_errors?(child)
+      if respond_to_errors?(child) || child.is_a?(Array)
         child
       else
         nil

--- a/app/helpers/govuk_elements_errors_helper.rb
+++ b/app/helpers/govuk_elements_errors_helper.rb
@@ -51,11 +51,22 @@ module GovukElementsErrorsHelper
 
   def self.instance_variable object, var
     field = var.to_s.sub('@','').to_sym
-    object.send(field) if object.respond_to?(field)
+    if object.respond_to?(field)
+      child = object.send(field)
+      if respond_to_errors?(child)
+        child
+      else
+        nil
+      end
+    end
+  end
+
+  def self.respond_to_errors? object
+    object && object.respond_to?(:errors)
   end
 
   def self.errors_present? object
-    object && object.respond_to?(:errors) && object.errors.present?
+    respond_to_errors?(object) && object.errors.present?
   end
 
   def self.children_with_errors object

--- a/app/helpers/govuk_elements_errors_helper.rb
+++ b/app/helpers/govuk_elements_errors_helper.rb
@@ -22,9 +22,12 @@ module GovukElementsErrorsHelper
     attributes(object).any? { |child| errors_exist?(child) }
   end
 
-  def self.attributes object
+  def self.attributes object, parent_object=nil
+    return [] if object == parent_object
+    parent_object ||= object
+
     child_objects = attribute_objects object
-    nested_child_objects = child_objects.map { |o| attributes(o) }
+    nested_child_objects = child_objects.map { |o| attributes(o, parent_object) }
     (child_objects + nested_child_objects).flatten
   end
 

--- a/app/helpers/govuk_elements_errors_helper.rb
+++ b/app/helpers/govuk_elements_errors_helper.rb
@@ -28,7 +28,7 @@ module GovukElementsErrorsHelper
 
     child_objects = attribute_objects object
     nested_child_objects = child_objects.map { |o| attributes(o, parent_object) }
-    (child_objects + nested_child_objects).flatten
+    (child_objects + nested_child_objects).flatten - [object]
   end
 
   def self.attribute_objects object

--- a/spec/dummy/app/models/case.rb
+++ b/spec/dummy/app/models/case.rb
@@ -1,0 +1,7 @@
+class Case
+  include ActiveModel::Model
+
+  attr_accessor :name
+  attr_accessor :state_machine
+  validates_presence_of :name
+end

--- a/spec/dummy/app/models/case.rb
+++ b/spec/dummy/app/models/case.rb
@@ -3,5 +3,11 @@ class Case
 
   attr_accessor :name
   attr_accessor :state_machine
+  attr_accessor :subcases
   validates_presence_of :name
+  validate :validate_subcases
+
+  def validate_subcases
+    subcases.each {|x| x.valid?} if subcases
+  end
 end

--- a/spec/dummy/app/models/state_machine.rb
+++ b/spec/dummy/app/models/state_machine.rb
@@ -1,0 +1,8 @@
+class StateMachine
+  include ActiveModel::Model
+
+  attr_accessor :object
+  attr_accessor :state
+  validates_presence_of :object
+
+end

--- a/spec/dummy/app/models/state_machine.rb
+++ b/spec/dummy/app/models/state_machine.rb
@@ -1,8 +1,9 @@
 class StateMachine
-  include ActiveModel::Model
 
   attr_accessor :object
   attr_accessor :state
-  validates_presence_of :object
 
+  def initialize object: object
+    @object = object
+  end
 end

--- a/spec/helpers/govuk_elements_errors_helper_spec.rb
+++ b/spec/helpers/govuk_elements_errors_helper_spec.rb
@@ -172,4 +172,18 @@ RSpec.describe GovukElementsErrorsHelper, type: :helper do
     end
   end
 
+  context 'recursion' do
+    let(:resource) do
+      kase = Case.new
+      kase.state_machine = StateMachine.new(object: kase)
+      kase.valid?
+      kase
+    end
+
+    it 'handles objects which contain objects with references to themselves' do
+      puts pretty_output
+    end
+  end
+
+
 end

--- a/spec/helpers/govuk_elements_errors_helper_spec.rb
+++ b/spec/helpers/govuk_elements_errors_helper_spec.rb
@@ -181,9 +181,8 @@ RSpec.describe GovukElementsErrorsHelper, type: :helper do
     end
 
     it 'handles objects which contain objects with references to themselves' do
-      puts pretty_output
+      expect(pretty_output).to include('<a href="#error_case_name">Name is required</a>')
     end
   end
-
 
 end


### PR DESCRIPTION
- Fix for the infinite loop, by preventing child object recursion following a circular reference.
- Also only traverse object instance variables that respond to errors() method, when looking for errors.
- Has been tested in [another app](https://github.com/ministryofjustice/correspondence_tool_staff/pull/121).

fixes https://github.com/ministryofjustice/govuk_elements_form_builder/issues/76