### PR TITLE
Add margin below legend via .heading-medium class

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -112,7 +112,7 @@ module GovukElementsFormBuilder
     end
 
     def fieldset_legend attribute
-      legend = content_tag(:legend) do
+      legend = content_tag(:legend, class: 'heading-medium') do
         tags = [content_tag(
                   :span,
                   fieldset_text(attribute),

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       expect_equal output, [
         '<div class="form-group">',
         '<fieldset>',
-        '<legend>',
+        '<legend class="heading-medium">',
         '<span class="form-label-bold">',
         'Where do you live?',
         '</span>',
@@ -288,7 +288,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       expect_equal output, [
         '<div class="form-group">',
         '<fieldset class="inline">',
-        '<legend>',
+        '<legend class="heading-medium">',
         '<span class="form-label-bold">',
         'Do you already have a personal user account?',
         '</span>',
@@ -315,7 +315,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
         expect_equal output, [
                        '<div class="form-group error" id="error_person_gender">',
                        '<fieldset>',
-                       '<legend>',
+                       '<legend class="heading-medium">',
                        '<span class="form-label-bold">',
                        'Gender',
                        '</span>',
@@ -348,7 +348,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       expect_equal output, [
         '<div class="form-group">',
         '<fieldset>',
-        '<legend>',
+        '<legend class="heading-medium">',
         '<span class="form-label-bold">',
         'Which types of waste do you transport regularly?',
         '</span>',


### PR DESCRIPTION
To obtain a bigger margin between legend text and new radio/checkbox buttons, set class .heading-medium on legend element.

This is similiar to the way the GOV.UK elements guide [uses .heading-medium](https://govuk-elements.herokuapp.com/form-elements/#form-radio-buttons) on the h1 elements in their examples.

Without this change the legend text appears [too close to radio/checkbox buttons](https://govuk-elements-rails-guide.herokuapp.com/form-elements#form-inline-radio-buttons-a-href-guidance-js-more-guidance-a), due to zero margin between them.