### PR TITLE
Add html attributes to label elements

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -28,11 +28,15 @@ module GovukElementsFormBuilder
       define_method(method_name) do |attribute, *args|
         content_tag :div, class: form_group_classes(attribute), id: form_group_id(attribute) do
           options = args.extract_options!
+
+          set_label_classes! options
           set_field_classes! options
 
-          label = label(attribute, class: "form-label")
+          label = label(attribute, options[:label_options])
+
           add_hint :label, label, attribute
-          (label + super(attribute, options.except(:label)) ).html_safe
+
+          (label + super(attribute, options.except(:label, :label_options))).html_safe
         end
       end
     end
@@ -90,6 +94,26 @@ module GovukElementsFormBuilder
                         else
                           options[:class] = text_field_class
                         end
+    end
+
+    def set_label_classes! options
+      text_field_class = "form-label"
+
+      if options.present? && options[:label_options].present?
+        options[:label_options][:class] = case options[:label_options][:class]
+                                            when String
+                                              [text_field_class, options[:label_options][:class]]
+                                            when Array
+                                              options[:label_options][:class].unshift text_field_class
+                                            else
+                                              options[:label_options][:class] = text_field_class
+                                          end
+      else
+        options ||= {}
+        options[:label_options] ||= {}
+        options[:label_options][:class] = text_field_class
+      end
+
     end
 
     def check_box_inputs attributes

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -29,16 +29,24 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     method == :text_area ? '' : %'type="#{type}" '
   end
 
+  def html_attributes(hash)
+    if  hash.present?
+      hash.map{|k,v| %'#{k}="#{v}" '}.join(' ')
+    end
+  end
+
   shared_examples_for 'input field' do |method, type|
 
     def size(method, size)
       (size.nil? || method == :text_area) ? '' : %'size="#{size}" '
     end
 
-    def expected_name_input_html method, type, classes=nil, size=nil
+    def expected_name_input_html method, type, classes=nil, size=nil, label_options=nil
+      label_options ||= {}
+      label_options[:class] ||= nil
       [
         '<div class="form-group">',
-        '<label class="form-label" for="person_name">',
+        %'<label #{html_attributes(label_options.except(:class, :for))}class="form-label#{label_options[:class]}" for="person_name">',
         'Full name',
         '</label>',
         %'<#{element_for(method)} #{size(method, size)}class="form-control#{classes}" #{type_for(method, type)}name="person[name]" id="person_name" />',
@@ -62,6 +70,20 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       output = builder.send method, :name, class: ['custom-class', 'another-class']
 
       expect_equal output, expected_name_input_html(method, type, ' custom-class another-class')
+    end
+
+    it 'adds custom classes to label when passed class: ["custom-class", "another-class"]' do
+      label_class_options = { class: ' custom-label-class another-label-class' }
+      output = builder.send method, :name, {label_options: {class: ['custom-label-class', 'another-label-class']}}
+
+      expect_equal output, expected_name_input_html( method, type, nil, nil, label_class_options)
+    end
+
+    it 'passes other html attribute to the label if they are provided' do
+      label_attr_options = { style: 'color:red;'}
+      output = builder.send method, :name, {label_options: {style: 'color:red;'}}
+
+      expect_equal output, expected_name_input_html( method, type, nil, nil, label_attr_options)
     end
 
     it 'passes options passed to text_field onto super text_field implementation' do


### PR DESCRIPTION
This adds an addition optional parameter to the following methods:
- email_field
- password_field
- number_field
- phone_field
- range_field
- search_field
- telephone_field
- text_area
- text_field
- url_field

The  original use case was to just add custom css classes to the
label element but I think a better approach would be to allow any
other html attribute to be added.

Usage eg.
```ruby
= form_for person do |f|
  - f.text_field :name, {label_options:{class: 'my-css-styles', style: 'color:red;'}}
```

label_options hash is optional and accept any html additional html
attribute you would like to use in the label.