### PR TITLE
Allow value and text method options to radio_button_fieldset (#82)

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -104,9 +104,17 @@ module GovukElementsFormBuilder
     def radio_inputs attribute, options
       choices = options[:choices] || [ :yes, :no ]
       choices.map do |choice|
-        label(attribute, class: 'block-label selection-button-radio', value: choice) do |tag|
-          input = radio_button(attribute, choice)
-          input + localized_label("#{attribute}.#{choice}")
+        value = choice.send(options[:value_method] || :to_s)
+        label attribute,
+              class: 'block-label selection-button-radio',
+              value: value do |tag|
+          input = radio_button(attribute, value)
+          text = if options.has_key? :text_method
+                   choice.send(options[:text_method])
+                 else
+                   localized_label("#{attribute}.#{choice}")
+                 end
+          input + text
         end
       end
     end

--- a/spec/dummy/app/models/case.rb
+++ b/spec/dummy/app/models/case.rb
@@ -1,9 +1,11 @@
 class Case
   include ActiveModel::Model
 
+  attr_accessor :id
   attr_accessor :name
   attr_accessor :state_machine
   attr_accessor :subcases
+
   validates_presence_of :name
   validate :validate_subcases
 

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -12,6 +12,7 @@ class Person
   attr_accessor :password_confirmation
   attr_accessor :waste_transport
   attr_accessor :gender
+  attr_accessor :case_id
 
   validates_presence_of :name, :gender
 

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -253,6 +253,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
   describe '#radio_button_fieldset' do
     let(:pretty_output) { HtmlBeautifier.beautify output }
+
     it 'outputs radio buttons wrapped in labels' do
       output = builder.radio_button_fieldset :location, choices: [:ni, :isle_of_man_channel_islands, :british_abroad]
       expect_equal output, [
@@ -306,6 +307,35 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       ]
     end
 
+    context 'with a couple associated cases' do
+      let(:case_1) { Case.new(id: 1, name: 'Case One')  }
+      let(:case_2) { Case.new(id: 2, name: 'Case Two')  }
+      let(:cases) { [case_1, case_2] }
+
+      it 'accepts value_method and text_method to better control generated HTML' do
+        output = builder.radio_button_fieldset :case_id, choices: cases, value_method: :id, text_method: :name, inline: true
+        expect_equal output, [
+                       '<div class="form-group">',
+                       '<fieldset class="inline">',
+                       '<legend>',
+                       '<span class="form-label-bold">',
+                       'Case',
+                       '</span>',
+                       '</legend>',
+                       '<label class="block-label selection-button-radio" for="person_case_id_1">',
+                       '<input type="radio" value="1" name="person[case_id]" id="person_case_id_1" />',
+                       'Case One',
+                       '</label>',
+                       '<label class="block-label selection-button-radio" for="person_case_id_2">',
+                       '<input type="radio" value="2" name="person[case_id]" id="person_case_id_2" />',
+                       'Case Two',
+                       '</label>',
+                       '</fieldset>',
+                       '</div>'
+                     ]
+
+      end
+    end
 
     context 'the resource is invalid' do
       let(:resource) { Person.new.tap { |p| p.valid? } }


### PR DESCRIPTION
**NOTE:** There are two changes here, one changes the existing `radio_buttons_fieldset` and the other adds a `collection_radio_buttons` method. See the discussion happening in issue #82, my proposal is that we just make the change to `radio_buttons_fieldset` for now and drop `collection_radio_buttons` until we can do it properly.

When generating a radio-button fieldset, there are times when we want to specify
how to get the form value or label text for the choices passed in, the same way
`collection_radio_buttons` does in Rails. For example, when assigning a team to
a person we may want to use the team's DB ID as the value and the team's name as
the radio button text. This change adds these options to
`radio_button_fieldset` (adding them to other places, such as
`check_box_fieldset`, is an exercise for later).

This addresses issue #82.