### PR TITLE
Add new error classes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,8 @@ PATH
   remote: .
   specs:
     govuk_elements_form_builder (0.0.5)
+      govuk_elements_rails (>= 3.0.0)
+      govuk_frontend_toolkit (>= 6.0.0)
       rails (>= 4.2)
 
 GEM
@@ -56,6 +58,13 @@ GEM
     formatador (0.2.5)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
+    govuk_elements_rails (3.0.2)
+      govuk_frontend_toolkit (>= 5.2.0)
+      rails (>= 4.1.0)
+      sass (>= 3.2.0)
+    govuk_frontend_toolkit (6.0.1)
+      rails (>= 3.1.0)
+      sass (>= 3.2.0)
     guard (2.13.0)
       formatador (>= 0.2.4)
       listen (>= 2.7, <= 4.0)
@@ -152,6 +161,7 @@ GEM
       rspec-mocks (~> 3.2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
+    sass (3.4.23)
     shellany (0.0.1)
     simplecov (0.12.0)
       docile (~> 1.1.0)

--- a/govuk_elements_form_builder.gemspec
+++ b/govuk_elements_form_builder.gemspec
@@ -17,6 +17,9 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
   s.add_dependency "rails", ">= 4.2"
+  # Needed to ensure correct css/js is available
+  s.add_dependency 'govuk_frontend_toolkit', '>= 6.0.0'
+  s.add_dependency 'govuk_elements_rails',   '>= 3.0.0'
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails"

--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -30,7 +30,7 @@ module GovukElementsFormBuilder
           options = args.extract_options!
 
           set_label_classes! options
-          set_field_classes! options
+          set_field_classes! options, attribute
 
           label = label(attribute, options[:label_options])
 
@@ -72,7 +72,7 @@ module GovukElementsFormBuilder
       content_tag :div, class: form_group_classes(method), id: form_group_id(method) do
 
         html_options = args.extract_options!
-        set_field_classes! html_options
+        set_field_classes! html_options, method
 
         label = label(method, class: "form-label")
         add_hint :label, label, method
@@ -84,8 +84,9 @@ module GovukElementsFormBuilder
 
     private
 
-    def set_field_classes! options
+    def set_field_classes! options, attribute
       text_field_class = "form-control"
+      text_field_class = [text_field_class, 'form-control-error'] if error_for? attribute
       options[:class] = case options[:class]
                         when String
                           [text_field_class, options[:class]]
@@ -230,7 +231,7 @@ module GovukElementsFormBuilder
     def form_group_classes attributes
       attributes = [attributes] if !attributes.respond_to? :count
       classes = 'form-group'
-      classes += ' error' if attributes.find { |a| error_for? a }
+      classes += ' form-group-error' if attributes.find { |a| error_for? a }
       classes
     end
 

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -221,14 +221,14 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
   def expected_error_html method, type, attribute, name_value, label, error
     [
-      %'<div class="form-group error" id="error_#{attribute}">',
+      %'<div class="form-group form-group-error" id="error_#{attribute}">',
       %'<label class="form-label" for="#{attribute}">',
       label,
       %'<span class="error-message" id="error_message_#{attribute}">',
       error,
       '</span>',
       '</label>',
-      %'<#{element_for(method)} aria-describedby="error_message_#{attribute}" class="form-control" #{type_for(method, type)}name="#{name_value}" id="#{attribute}" />',
+      %'<#{element_for(method)} aria-describedby="error_message_#{attribute}" class="form-control form-control-error" #{type_for(method, type)}name="#{name_value}" id="#{attribute}" />',
       '</div>'
     ]
   end
@@ -379,7 +379,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       it 'outputs error messages' do
         output = builder.radio_button_fieldset :gender
         expect_equal output, [
-                       '<div class="form-group error" id="error_person_gender">',
+                       '<div class="form-group form-group-error" id="error_person_gender">',
                        '<fieldset>',
                        '<legend>',
                        '<span class="form-label-bold">',


### PR DESCRIPTION
This commit updates the error classes used in the form builder
in line with govuk_element v3

https://github.com/alphagov/govuk_elements/releases/tag/v3.0.0

I added GOVUK Elements and GOVUK Frontend toolkit as dependencies
for the form builder as it is now relying on specific css classes to
display correctly and will help developers identify why their pages
are not displaying correctly.

Part of a V1 build which will include #85 