### PR TITLE
Support for namespaced resources when generating error anchors.

### DIFF
--- a/app/helpers/govuk_elements_errors_helper.rb
+++ b/app/helpers/govuk_elements_errors_helper.rb
@@ -178,8 +178,9 @@ module GovukElementsErrorsHelper
     end
   end
 
+  # `underscore` changes '::' to '/' to convert namespaces to paths
   def self.underscore_name object
-    object.class.name.underscore
+    object.class.name.underscore.tr('/'.freeze, '_'.freeze)
   end
 
   private_class_method :error_summary_div

--- a/spec/dummy/app/models/steps/appeal/penalty.rb
+++ b/spec/dummy/app/models/steps/appeal/penalty.rb
@@ -1,0 +1,9 @@
+module Steps::Appeal
+  class Penalty
+    include ActiveModel::Model
+
+    attr_accessor :amount
+
+    validates_presence_of :amount
+  end
+end

--- a/spec/helpers/govuk_elements_errors_helper_spec.rb
+++ b/spec/helpers/govuk_elements_errors_helper_spec.rb
@@ -75,6 +75,18 @@ RSpec.describe GovukElementsErrorsHelper, type: :helper do
         end
       end
     end
+
+    context 'for a namespaced resource' do
+      let(:resource) { Steps::Appeal::Penalty.new.tap { |p| p.valid? } }
+
+      it 'outputs the specific error message with correct anchoring' do
+        expect(pretty_output).to have_tag('div.error-summary') do
+          with_tag 'ul.error-summary-list' do
+            with_tag 'a[href="#error_steps_appeal_penalty_amount"]', 'Amount is required'
+          end
+        end
+      end
+    end
   end
 
   describe '#error_summary when child object has validation errors' do


### PR DESCRIPTION
We've faced this issue where using namespaced resources/models will generate incorrect
anchor tags in the error summary, due to the '::' being left as '/' instead of the
expect '_' to match the ID of the form element producing the error.

Basically, the code generating the form element error ID is different to the code
generating the error summary anchor link, and thus this situation.

A better solution would be to make sure the exact same code is used in both places, but
due to the different contexts (form builder and helper) this is also not ideal.