### PR TITLE
Configure Code climate to ignore Gemfile.lock

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -22,3 +22,5 @@ ratings:
   - "**.rb"
 exclude_paths:
 - spec/
+- Gemfile.lock
+


### PR DESCRIPTION
The reasons this was added is because it affects the score
code climate gives and it shouldn't matter as this file is only
used for testing the dummy rails app in the spec directory.