### PR TITLE
Ability to provide html attributes to fieldset legends

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -47,7 +47,7 @@ module GovukElementsFormBuilder
                   id: form_group_id(attribute) do
         content_tag :fieldset, fieldset_options(attribute, options) do
           safe_join([
-                      fieldset_legend(attribute),
+                      fieldset_legend(attribute, options),
                       radio_inputs(attribute, options)
                     ], "\n")
         end
@@ -60,7 +60,7 @@ module GovukElementsFormBuilder
                   id: form_group_id(attributes) do
         content_tag :fieldset, fieldset_options(attributes, options) do
           safe_join([
-                      fieldset_legend(legend_key),
+                      fieldset_legend(legend_key, options),
                       check_box_inputs(attributes)
                     ], "\n")
         end
@@ -143,12 +143,12 @@ module GovukElementsFormBuilder
       end
     end
 
-    def fieldset_legend attribute
+    def fieldset_legend attribute, options
       legend = content_tag(:legend) do
         tags = [content_tag(
                   :span,
                   fieldset_text(attribute),
-                  class: 'form-label-bold'
+                  options.fetch(:legend_options, class: 'form-label-bold')
                 )]
 
         if error_for? attribute

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -329,6 +329,11 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       ]
     end
 
+    it 'propagates html attributes down to the legend inner span if any provided' do
+      output = builder.radio_button_fieldset :has_user_account, inline: true, legend_options: {class: 'visuallyhidden'}
+      expect(output).to match(/<legend><span class="visuallyhidden">/)
+    end
+
     context 'with a couple associated cases' do
       let(:case_1) { Case.new(id: 1, name: 'Case One')  }
       let(:case_2) { Case.new(id: 2, name: 'Case Two')  }
@@ -391,8 +396,11 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
   end
 
   describe '#check_box_fieldset' do
-    it 'outputs checkboxes wrapped in labels' do
+    before do
       resource.waste_transport = WasteTransport.new
+    end
+
+    it 'outputs checkboxes wrapped in labels' do
       output = builder.fields_for(:waste_transport) do |f|
         f.check_box_fieldset :waste_transport, [:animal_carcasses, :mines_quarries, :farm_agricultural]
       end
@@ -432,6 +440,12 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       ]
     end
 
+    it 'propagates html attributes down to the legend inner span if any provided' do
+      output = builder.fields_for(:waste_transport) do |f|
+        f.check_box_fieldset :waste_transport, [:animal_carcasses, :mines_quarries, :farm_agricultural], legend_options: {class: 'visuallyhidden'}
+      end
+      expect(output).to match(/<legend><span class="visuallyhidden">/)
+    end
   end
 
   describe '#collection_select' do


### PR DESCRIPTION
This PR will add the ability to propagate html attributes down to the legend
inner element (`span` at the moment) for the `radio_button_fieldset` and
`check_box_fieldset` methods.

This solves an accessibility issue we were facing: legends need to exist for
screen reader users, but we wanted them to be visually hidden for non screen
reader users, and this was not possible with the current version of the gem.

Now, you can provide an optional hash as in these examples:

```ruby
f.radio_button_fieldset :case_type, choices: [...],
  legend_options: {class: 'visuallyhidden'}

f.check_box_fieldset :waste_transport, [...],
  legend_options: {class: 'visuallyhidden'}
```

And the legend element will produce the following markup:

```html
<legend>
  <span class="visuallyhidden">What is your appeal about?</span>
</legend>
```

Or, when errors found:

```html
<legend>
  <span class="visuallyhidden">What is your appeal about?</span>
  <span class="error-message">Select what your appeal is about</span>
</legend>
```

Note the `legend_options`, if provided, will overwrite the current span class
`form-label-bold`. If not provided, the current behaviour remains unchanged.

The most common scenario if `legend_options` is provided is to customize the
span so overwriting the hardcoded class is preferible. If you want to maintain
the `form-label-bold` AND provide extra attributes, make sure to add it to your
options, i.e. `legend_options: {class: 'form-label-bold color-red', id: 'test'}`

This also ensures backward-compatibility.