### PR TITLE
Ability to provide html attributes to fieldset legends (v1)

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -47,7 +47,7 @@ module GovukElementsFormBuilder
                   id: form_group_id(attribute) do
         content_tag :fieldset, fieldset_options(attribute, options) do
           safe_join([
-                      fieldset_legend(attribute),
+                      fieldset_legend(attribute, options),
                       radio_inputs(attribute, options)
                     ], "\n")
         end
@@ -60,7 +60,7 @@ module GovukElementsFormBuilder
                   id: form_group_id(attributes) do
         content_tag :fieldset, fieldset_options(attributes, options) do
           safe_join([
-                      fieldset_legend(legend_key),
+                      fieldset_legend(legend_key, options),
                       check_box_inputs(attributes)
                     ], "\n")
         end
@@ -148,12 +148,12 @@ module GovukElementsFormBuilder
       end
     end
 
-    def fieldset_legend attribute
+    def fieldset_legend attribute, options
       legend = content_tag(:legend) do
         tags = [content_tag(
                   :span,
                   fieldset_text(attribute),
-                  class: 'form-label-bold'
+                  options.fetch(:legend_options, class: 'form-label-bold')
                 )]
 
         if error_for? attribute

--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -84,37 +84,32 @@ module GovukElementsFormBuilder
 
     private
 
+    # Given an attributes hash that could include any number of arbitrary keys, this method
+    # ensure we merge one or more 'default' attributes into the hash, creating the keys if
+    # don't exist, or merging the defaults if the keys already exists.
+    # It supports strings or arrays as values.
+    #
+    def merge_attributes attributes, default:
+      hash = attributes || {}
+      hash.merge(default) { |_key, oldval, newval| Array(newval) + Array(oldval) }
+    end
+
     def set_field_classes! options, attribute
-      text_field_class = "form-control"
-      text_field_class = [text_field_class, 'form-control-error'] if error_for? attribute
-      options[:class] = case options[:class]
-                        when String
-                          [text_field_class, options[:class]]
-                        when Array
-                          options[:class].unshift text_field_class
-                        else
-                          options[:class] = text_field_class
-                        end
+      default_classes = ['form-control']
+      default_classes << 'form-control-error' if error_for?(attribute)
+
+      options ||= {}
+      options.merge!(
+        merge_attributes(options, default: {class: default_classes})
+      )
     end
 
     def set_label_classes! options
-      text_field_class = "form-label"
-
-      if options.present? && options[:label_options].present?
-        options[:label_options][:class] = case options[:label_options][:class]
-                                            when String
-                                              [text_field_class, options[:label_options][:class]]
-                                            when Array
-                                              options[:label_options][:class].unshift text_field_class
-                                            else
-                                              options[:label_options][:class] = text_field_class
-                                          end
-      else
-        options ||= {}
-        options[:label_options] ||= {}
-        options[:label_options][:class] = text_field_class
-      end
-
+      options ||= {}
+      options[:label_options] ||= {}
+      options[:label_options].merge!(
+        merge_attributes(options[:label_options], default: {class: 'form-label'})
+      )
     end
 
     def check_box_inputs attributes
@@ -153,7 +148,7 @@ module GovukElementsFormBuilder
         tags = [content_tag(
                   :span,
                   fieldset_text(attribute),
-                  options.fetch(:legend_options, class: 'form-label-bold')
+                  merge_attributes(options[:legend_options], default: {class: 'form-label-bold'})
                 )]
 
         if error_for? attribute

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -339,9 +339,9 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       ]
     end
 
-    it 'propagates html attributes down to the legend inner span if any provided' do
-      output = builder.radio_button_fieldset :has_user_account, inline: true, legend_options: {class: 'visuallyhidden'}
-      expect(output).to match(/<legend><span class="visuallyhidden">/)
+    it 'propagates html attributes down to the legend inner span if any provided, appending to the defaults' do
+      output = builder.radio_button_fieldset :has_user_account, inline: true, legend_options: {class: 'visuallyhidden', lang: 'en'}
+      expect(output).to match(/<legend><span class="form-label-bold visuallyhidden" lang="en">/)
     end
 
     context 'with a couple associated cases' do
@@ -465,11 +465,11 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       ]
     end
 
-    it 'propagates html attributes down to the legend inner span if any provided' do
+    it 'propagates html attributes down to the legend inner span if any provided, appending to the defaults' do
       output = builder.fields_for(:waste_transport) do |f|
-        f.check_box_fieldset :waste_transport, [:animal_carcasses, :mines_quarries, :farm_agricultural], legend_options: {class: 'visuallyhidden'}
+        f.check_box_fieldset :waste_transport, [:animal_carcasses, :mines_quarries, :farm_agricultural], legend_options: {class: 'visuallyhidden', lang: 'en'}
       end
-      expect(output).to match(/<legend><span class="visuallyhidden">/)
+      expect(output).to match(/<legend><span class="form-label-bold visuallyhidden" lang="en">/)
     end
   end
 

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -339,6 +339,11 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       ]
     end
 
+    it 'propagates html attributes down to the legend inner span if any provided' do
+      output = builder.radio_button_fieldset :has_user_account, inline: true, legend_options: {class: 'visuallyhidden'}
+      expect(output).to match(/<legend><span class="visuallyhidden">/)
+    end
+
     context 'with a couple associated cases' do
       let(:case_1) { Case.new(id: 1, name: 'Case One')  }
       let(:case_2) { Case.new(id: 2, name: 'Case Two')  }
@@ -409,7 +414,11 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
   end
 
   describe '#check_box_fieldset' do
-    it 'outputs checkboxes in a stacked layout' do
+    before do
+      resource.waste_transport = WasteTransport.new
+    end
+
+    it 'outputs checkboxes wrapped in labels' do
       resource.waste_transport = WasteTransport.new
       output = builder.fields_for(:waste_transport) do |f|
         f.check_box_fieldset :waste_transport, [:animal_carcasses, :mines_quarries, :farm_agricultural]
@@ -456,6 +465,12 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       ]
     end
 
+    it 'propagates html attributes down to the legend inner span if any provided' do
+      output = builder.fields_for(:waste_transport) do |f|
+        f.check_box_fieldset :waste_transport, [:animal_carcasses, :mines_quarries, :farm_agricultural], legend_options: {class: 'visuallyhidden'}
+      end
+      expect(output).to match(/<legend><span class="visuallyhidden">/)
+    end
   end
 
   describe '#collection_select' do


### PR DESCRIPTION
Replicates the PR #89 but for the v1.x of the gem.
Please refer to the above PR for details and code examples.