### PR TITLE
Extend functionality to allow revealing panels

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,21 @@
 ---
+version: "2"
+checks:
+  file-lines:
+    config:
+      threshold: 300
+  method-lines:
+    enabled: true
+    config:
+      threshold: 30
+  similar-code:
+    enabled: true
+    config:
+      threshold: 36
+  identical-code:
+    enabled: true
+    config:
+      threshold: 18
 engines:
   bundler-audit:
     enabled: true

--- a/lib/govuk_elements_form_builder.rb
+++ b/lib/govuk_elements_form_builder.rb
@@ -1,5 +1,6 @@
 require 'govuk_elements_form_builder/version'
 require 'govuk_elements_form_builder/form_builder'
+require 'govuk_elements_form_builder/block_buffer'
 require_relative '../app/helpers/govuk_elements_errors_helper'
 
 module GovukElementsFormBuilder

--- a/lib/govuk_elements_form_builder/block_buffer.rb
+++ b/lib/govuk_elements_form_builder/block_buffer.rb
@@ -1,0 +1,29 @@
+module GovukElementsFormBuilder
+  #
+  # This class is intended to be a proxy for a FormBuilder object, and accumulate
+  # multiple form elements rendered inside a block. Its main reason for existence is
+  # to enable the following syntax when rendering revealing panels:
+  #
+  # f.radio_button_fieldset :asked_for_help do |fieldset|
+  #   fieldset.radio_input(GenericYesNo::YES) do |radio|
+  #     # Here, `radio` is a `BlockBuffer` instance, delegating all methods to
+  #     # a `FormBuilder` instance, but doing the accumulation/concatenation.
+  #     radio.text_field(:help_party)
+  #     radio.text_field(:another_field)
+  #     [...]
+  #   end
+  #   fieldset.radio_input(GenericYesNo::NO)
+  # end
+  #
+  class BlockBuffer
+    delegate :safe_concat, :send, to: :@form_object
+
+    def initialize(form_object)
+      @form_object = form_object
+    end
+
+    def method_missing(method, *args, &block)
+      safe_concat send(method, *args, &block)
+    end
+  end
+end

--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -92,10 +92,10 @@ module GovukElementsFormBuilder
     def radio_input choice, options = {}, &block
       fieldset_attribute = self.current_fieldset_attribute
 
-      panel = if block_given?
+      panel = if block_given? || options.key?(:panel_id)
         panel_id = options.delete(:panel_id) { [fieldset_attribute, choice, 'panel'].join('_') }
         options.merge!('data-target': panel_id)
-        revealing_panel(panel_id, &block)
+        revealing_panel(panel_id, flush: false, &block) if block_given?
       end
 
       option = radio_inputs(
@@ -104,6 +104,14 @@ module GovukElementsFormBuilder
       ).first + "\n"
 
       safe_concat([option, panel].join)
+    end
+
+    def revealing_panel panel_id, options = {}, &block
+      panel = content_tag(
+        :div, class: 'panel panel-border-narrow js-hidden', id: panel_id
+      ) { block.call(BlockBuffer.new(self)) } + "\n"
+
+      options.fetch(:flush, true) ? safe_concat(panel) : panel
     end
 
     private
@@ -202,12 +210,6 @@ module GovukElementsFormBuilder
       fieldset_options = {}
       fieldset_options[:class] = 'inline' if options[:inline] == true
       fieldset_options
-    end
-
-    def revealing_panel panel_id, &block
-      content_tag(
-        :div, class: 'panel panel-border-narrow js-hidden', id: panel_id
-      ) { block.call } + "\n"
     end
 
     private_class_method def self.add_error_to_html_tag! html_tag, instance

--- a/spec/dummy/app/models/person.rb
+++ b/spec/dummy/app/models/person.rb
@@ -6,6 +6,7 @@ class Person
   attr_accessor :email_home
   attr_accessor :has_user_account
   attr_accessor :location
+  attr_accessor :location_other
   attr_accessor :name
   attr_accessor :ni_number
   attr_accessor :password

--- a/spec/dummy/app/models/waste_transport.rb
+++ b/spec/dummy/app/models/waste_transport.rb
@@ -3,6 +3,8 @@ class WasteTransport
 
   attr_accessor :animal_carcasses
   attr_accessor :mines_quarries
+  attr_accessor :mines_quarries_details
   attr_accessor :farm_agricultural
+  attr_accessor :farm_agricultural_details
 
 end

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -39,8 +39,10 @@ en:
           ni: Northern Ireland
           isle_of_man_channel_islands: Isle of Man or Channel Islands
           british_abroad: I am a British citizen living abroad
+          other: Other location
         name: Full name
         ni_number: National Insurance number
+        location_other: Please enter your location
         password: Password
         password_confirmation: Confirm password
       person[address_attributes]:

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -339,6 +339,61 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       ]
     end
 
+    it 'outputs markup with support for revealing panels' do
+      output = builder.radio_button_fieldset :location do |fieldset|
+        fieldset.radio_input(:england)
+        fieldset.radio_input(:other) {
+          fieldset.text_field :location_other
+        }
+      end
+
+      expect_equal output, [
+      '<div class="form-group">',
+        '<fieldset>',
+        '<legend>',
+        '<span class="form-label-bold">',
+        'Where do you live?',
+        '</span>',
+        '<span class="form-hint">',
+        'Select from these options because you answered you do not reside in England, Wales, or Scotland',
+        '</span>',
+        '</legend>',
+        '<div class="multiple-choice">',
+        '<input type="radio" value="england" name="person[location]" id="person_location_england" />',
+        '<label for="person_location_england">',
+        'England',
+        '</label>',
+        '</div>',
+        '<div class="multiple-choice" data-target="location_other_panel">',
+        '<input type="radio" value="other" name="person[location]" id="person_location_other" />',
+        '<label for="person_location_other">',
+        'Other location',
+        '</label>',
+        '</div>',
+        '<div class="panel panel-border-narrow js-hidden" id="location_other_panel">',
+        '<div class="form-group">',
+        '<label class="form-label" for="person_location_other">',
+        'Please enter your location',
+        '</label>',
+        '<input class="form-control" type="text" name="person[location_other]" id="person_location_other" />',
+        '</div>',
+        '</div>',
+        '</fieldset>',
+        '</div>'
+      ]
+    end
+
+    it 'outputs markup with support for revealing panels with specific ID' do
+      output = builder.radio_button_fieldset :location do |fieldset|
+        fieldset.radio_input(:england)
+        fieldset.radio_input(:other, panel_id: 'another_location_input') {
+          fieldset.text_field :location_other
+        }
+      end
+
+      expect(output).to match(/<div class="multiple-choice" data-target="another_location_input">/)
+    end
+
     context 'with a couple associated cases' do
       let(:case_1) { Case.new(id: 1, name: 'Case One')  }
       let(:case_2) { Case.new(id: 2, name: 'Case Two')  }
@@ -487,7 +542,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       expect_equal output, [
           '<div class="form-group">',
           '<label class="form-label" for="person_location">',
-          '{:ni=&gt;&quot;Northern Ireland&quot;, :isle_of_man_channel_islands=&gt;&quot;Isle of Man or Channel Islands&quot;, :british_abroad=&gt;&quot;I am a British citizen living abroad&quot;}',
+          '{:ni=&gt;&quot;Northern Ireland&quot;, :isle_of_man_channel_islands=&gt;&quot;Isle of Man or Channel Islands&quot;, :british_abroad=&gt;&quot;I am a British citizen living abroad&quot;, :other=&gt;&quot;Other location&quot;}',
           %'<span class="form-hint">',
           'Select from these options because you answered you do not reside in England, Wales, or Scotland',
           %'</span>',

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -551,6 +551,84 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       ]
     end
 
+    it 'outputs markup with support for revealing panels' do
+      resource.waste_transport = WasteTransport.new
+      output = builder.fields_for(:waste_transport) do |f|
+        f.check_box_fieldset :waste_transport, [:animal_carcasses, :mines_quarries, :farm_agricultural] do |fieldset|
+          fieldset.check_box_input(:animal_carcasses)
+          fieldset.check_box_input(:mines_quarries) { f.text_field :mines_quarries_details }
+          fieldset.check_box_input(:farm_agricultural) { f.text_field :farm_agricultural_details }
+        end
+      end
+
+      expect_equal output, [
+        '<div class="form-group">',
+        '<fieldset>',
+        '<legend>',
+        '<span class="form-label-bold">',
+        'Which types of waste do you transport regularly?',
+        '</span>',
+        '<span class="form-hint">',
+        'Select all that apply',
+        '</span>',
+        '</legend>',
+        '<div class="multiple-choice">',
+        '<input name="person[waste_transport_attributes][animal_carcasses]" type="hidden" value="0" />',
+        '<input type="checkbox" value="1" name="person[waste_transport_attributes][animal_carcasses]" id="person_waste_transport_attributes_animal_carcasses" />',
+        '<label for="person_waste_transport_attributes_animal_carcasses">',
+        'Waste from animal carcasses',
+        '<br>',
+        '<em>',
+        'includes sloths and other Bradypodidae',
+        '</em>',
+        '</label>',
+        '</div>',
+        '<div class="multiple-choice" data-target="mines_quarries_panel">',
+        '<input name="person[waste_transport_attributes][mines_quarries]" type="hidden" value="0" />',
+        '<input type="checkbox" value="1" name="person[waste_transport_attributes][mines_quarries]" id="person_waste_transport_attributes_mines_quarries" />',
+        '<label for="person_waste_transport_attributes_mines_quarries">',
+        'Waste from mines or quarries (&gt; 200 lbs)',
+        '</label>',
+        '</div>',
+        '<div class="panel panel-border-narrow js-hidden" id="mines_quarries_panel">',
+        '<div class="form-group">',
+        '<label class="form-label" for="person_waste_transport_attributes_mines_quarries_details">',
+        'Mines quarries details',
+        '</label>',
+        '<input class="form-control" type="text" name="person[waste_transport_attributes][mines_quarries_details]" id="person_waste_transport_attributes_mines_quarries_details" />',
+        '</div>',
+        '</div>',
+        '<div class="multiple-choice" data-target="farm_agricultural_panel">',
+        '<input name="person[waste_transport_attributes][farm_agricultural]" type="hidden" value="0" />',
+        '<input type="checkbox" value="1" name="person[waste_transport_attributes][farm_agricultural]" id="person_waste_transport_attributes_farm_agricultural" />',
+        '<label for="person_waste_transport_attributes_farm_agricultural">',
+        'Farm or agricultural waste',
+        '</label>',
+        '</div>',
+        '<div class="panel panel-border-narrow js-hidden" id="farm_agricultural_panel">',
+        '<div class="form-group">',
+        '<label class="form-label" for="person_waste_transport_attributes_farm_agricultural_details">',
+        'Farm agricultural details',
+        '</label>',
+        '<input class="form-control" type="text" name="person[waste_transport_attributes][farm_agricultural_details]" id="person_waste_transport_attributes_farm_agricultural_details" />',
+        '</div>',
+        '</div>',
+        '</fieldset>',
+        '</div>'
+      ]
+    end
+
+    it 'outputs markup with support for revealing panels with specific ID' do
+      resource.waste_transport = WasteTransport.new
+      output = builder.fields_for(:waste_transport) do |f|
+        f.check_box_fieldset :waste_transport, [:animal_carcasses, :mines_quarries] do |fieldset|
+          fieldset.check_box_input(:animal_carcasses)
+          fieldset.check_box_input(:mines_quarries, panel_id: 'mines_quarries_details_text_field_input')
+        end
+      end
+
+      expect(output).to match(/<div class="multiple-choice" data-target="mines_quarries_details_text_field_input">/)
+    end
   end
 
   describe '#collection_select' do

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -273,6 +273,48 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     include_examples 'input field', :url_field, :url
   end
 
+  describe '#revealing_panel' do
+    let(:pretty_output) { HtmlBeautifier.beautify output }
+
+    it 'outputs revealing panel markup' do
+      output = builder.radio_button_fieldset :location do |fieldset|
+        fieldset.revealing_panel(:location_panel) do |panel|
+          panel.text_field :location_other
+          panel.text_field :address
+        end
+      end
+
+      expect_equal output, [
+        '<div class="form-group">',
+        '<fieldset>',
+        '<legend>',
+        '<span class="form-label-bold">',
+        'Where do you live?',
+        '</span>',
+        '<span class="form-hint">',
+        'Select from these options because you answered you do not reside in England, Wales, or Scotland',
+        '</span>',
+        '</legend>',
+        '<div class="panel panel-border-narrow js-hidden" id="location_panel">',
+        '<div class="form-group">',
+        '<label class="form-label" for="person_location_other">',
+        'Please enter your location',
+        '</label>',
+        '<input class="form-control" type="text" name="person[location_other]" id="person_location_other" />',
+        '</div>',
+        '<div class="form-group">',
+        '<label class="form-label" for="person_address">',
+        'Address',
+        '</label>',
+        '<input class="form-control" type="text" name="person[address]" id="person_address" />',
+        '</div>',
+        '</div>',
+        '</fieldset>',
+        '</div>'
+      ]
+    end
+  end
+
   describe '#radio_button_fieldset' do
     let(:pretty_output) { HtmlBeautifier.beautify output }
 
@@ -386,9 +428,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     it 'outputs markup with support for revealing panels with specific ID' do
       output = builder.radio_button_fieldset :location do |fieldset|
         fieldset.radio_input(:england)
-        fieldset.radio_input(:other, panel_id: 'another_location_input') {
-          fieldset.text_field :location_other
-        }
+        fieldset.radio_input(:other, panel_id: 'another_location_input')
       end
 
       expect(output).to match(/<div class="multiple-choice" data-target="another_location_input">/)


### PR DESCRIPTION
This PR will extend the functionality (but still NO breaking changes and
totally backward compatible) for radio options and check boxes to reveal/hide 
linked panels with content inside, following the GOV.UK elements guidelines:

https://govuk-elements.herokuapp.com/form-elements/#form-toggle-content

Example of use for radio options:

In this case, the radio button list includes one option "Do you have a 'help with fees' reference number?" If the user clicks to select that radio button, extra content is revealed including a text field for the user to enter their reference number.

```ruby
f.radio_button_fieldset :help_paying do |fieldset|
  fieldset.radio_input(HelpPaying::YES_WITH_REF_NUMBER) {
    f.text_field :hwf_reference_number
  }
  fieldset.radio_input(HelpPaying::YES_WITHOUT_REF_NUMBER) {
    t('.hwf_reference_number_help_html')
  }
  fieldset.radio_input(HelpPaying::NOT_NEEDED)
end
```

The revealed content panel ID is autogenerated, but if you need a specific ID, you can
pass it like this:

```ruby
fieldset.radio_input(HelpPaying::YES_WITH_REF_NUMBER, panel_id: 'foo') {
  f.text_field :hwf_reference_number
}
```

Example of use for check boxes:

In this case, the user ticks the checkbox for "I don't know the date of birth," and is then shown a text field in which to enter their estimate of the person's age.

```ruby
f.check_box_fieldset :dob_unknown, [:dob_unknown] do |fieldset|
  fieldset.check_box_input(:dob_unknown) { f.text_field :age_estimate }
end
```

The revealed content panel does not have to be directly adjacent to the radio button or checkbox that reveals it. As part of commit a1849b0, you can also create a panel elsewhere in the fieldset, which is especially useful when you need radio buttons inside radio button lists:

In this case, the user clicks a radio button to indicate that they have asked for help, and is shown a text field to enter whom they asked, and a pair of yes/no radio buttons to indicate whether or not they received help.

```ruby
f.radio_button_fieldset :asked_for_help, inline: true do |fieldset|
  fieldset.radio_input(GenericYesNo::YES, panel_id: :asked_for_help_panel)
  fieldset.radio_input(GenericYesNo::NO)
  fieldset.revealing_panel(:asked_for_help_panel) do |panel|
    panel.text_field(:help_party)
    panel.radio_button_fieldset(:help_provided, inline: true, choices: GenericYesNo.values)
    panel.text_area(:help_description, size: '40x4', class: 'form-control-3-4')
  end
end
```