### PR TITLE
Add ability to override the legend text

### DIFF
--- a/lib/govuk_elements_form_builder/form_builder.rb
+++ b/lib/govuk_elements_form_builder/form_builder.rb
@@ -230,10 +230,12 @@ module GovukElementsFormBuilder
     end
 
     def fieldset_legend attribute, options
+      legend_text = options.fetch(:legend_options, {}).delete(:text)
+
       legend = content_tag(:legend) do
         tags = [content_tag(
                   :span,
-                  fieldset_text(attribute),
+                  legend_text || fieldset_text(attribute),
                   merge_attributes(options[:legend_options], default: {class: 'form-label-bold'})
                 )]
 

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -439,6 +439,11 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       expect(output).to match(/<legend><span class="form-label-bold visuallyhidden" lang="en">/)
     end
 
+    it 'can override the legend text' do
+      output = builder.radio_button_fieldset :has_user_account, inline: true, legend_options: { text: 'A custom legend' }
+      expect(output).to match(/<legend><span class="form-label-bold">A custom legend<\/span>/)
+    end
+
     context 'with a couple associated cases' do
       let(:case_1) { Case.new(id: 1, name: 'Case One')  }
       let(:case_2) { Case.new(id: 2, name: 'Case Two')  }
@@ -647,6 +652,13 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
         f.check_box_fieldset :waste_transport, [:animal_carcasses, :mines_quarries, :farm_agricultural], legend_options: {class: 'visuallyhidden', lang: 'en'}
       end
       expect(output).to match(/<legend><span class="form-label-bold visuallyhidden" lang="en">/)
+    end
+
+    it 'can override the legend text' do
+      output = builder.fields_for(:waste_transport) do |f|
+        f.check_box_fieldset :waste_transport, [:animal_carcasses, :mines_quarries, :farm_agricultural], legend_options: { text: 'A custom legend' }
+      end
+      expect(output).to match(/<legend><span class="form-label-bold">A custom legend<\/span>/)
     end
   end
 


### PR DESCRIPTION
There are some situations where the legend text can't just be picked from locales, for example because it has dynamic content. We need this in one of our services.

With this small change we provide the ability to pass the content of the legend text.

It uses the same existing `legend_options` hash and adds a new `text` option.
It is completely backwards compatible and the default behaviour continues to be to pick the legend text from i18n locales.