### PR TITLE
Bump gem version to 1.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    govuk_elements_form_builder (1.3.0)
+    govuk_elements_form_builder (1.3.1)
       govuk_elements_rails (>= 3.0.0)
-      govuk_frontend_toolkit (>= 6.0.0)
+      govuk_frontend_toolkit (< 9.0.0)
       rails (>= 4.2)
 
 GEM
@@ -63,7 +63,7 @@ GEM
       govuk_frontend_toolkit (>= 6.0.2)
       rails (>= 4.1.0)
       sass (>= 3.2.0)
-    govuk_frontend_toolkit (8.1.0)
+    govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
     guard (2.13.0)
@@ -94,7 +94,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.8.2)
-    mini_mime (1.0.1)
+    mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     nenv (0.3.0)
@@ -162,7 +162,7 @@ GEM
       rspec-mocks (~> 3.2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
-    sass (3.7.3)
+    sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -201,4 +201,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.0
+   1.17.3

--- a/govuk_elements_form_builder.gemspec
+++ b/govuk_elements_form_builder.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 4.2"
   # Needed to ensure correct css/js is available
-  s.add_dependency 'govuk_frontend_toolkit', '>= 6.0.0'
+  s.add_dependency 'govuk_frontend_toolkit', '< 9.0.0'
   s.add_dependency 'govuk_elements_rails',   '>= 3.0.0'
 
   s.add_development_dependency "sqlite3"

--- a/lib/govuk_elements_form_builder/version.rb
+++ b/lib/govuk_elements_form_builder/version.rb
@@ -1,3 +1,3 @@
 module GovukElementsFormBuilder
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
   include TranslationHelper
 
   it "should have a version" do
-    expect(GovukElementsFormBuilder::VERSION).to eq("1.3.0")
+    expect(GovukElementsFormBuilder::VERSION).to eq("1.3.1")
   end
 
   let(:helper) { TestHelper.new }


### PR DESCRIPTION
Note: due to a breaking change in `govuk_frontend_toolkit` v9.0.0, this gem is now locked to use `< 9.0.0` as a safe measure for any old projects depending on this gem.