### PR TITLE
Make specs less brittle by replacing HTML comparison with matchers

### DIFF
--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -296,51 +296,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     include_examples 'input field', :url_field, :url
   end
 
-  describe '#revealing_panel' do
-    let(:pretty_output) { HtmlBeautifier.beautify output }
-
-    it 'outputs revealing panel markup' do
-      output = builder.radio_button_fieldset :location do |fieldset|
-        fieldset.revealing_panel(:location_panel) do |panel|
-          panel.text_field :location_other
-          panel.text_field :address
-        end
-      end
-
-      expect_equal output, [
-        '<div class="form-group">',
-        '<fieldset>',
-        '<legend>',
-        '<span class="form-label-bold">',
-        'Where do you live?',
-        '</span>',
-        '<span class="form-hint">',
-        'Select from these options because you answered you do not reside in England, Wales, or Scotland',
-        '</span>',
-        '</legend>',
-        '<div class="panel panel-border-narrow js-hidden" id="location_panel">',
-        '<div class="form-group">',
-        '<label class="form-label" for="person_location_other">',
-        'Please enter your location',
-        '</label>',
-        '<input class="form-control" type="text" name="person[location_other]" id="person_location_other" />',
-        '</div>',
-        '<div class="form-group">',
-        '<label class="form-label" for="person_address">',
-        'Address',
-        '</label>',
-        '<input class="form-control" type="text" name="person[address]" id="person_address" />',
-        '</div>',
-        '</div>',
-        '</fieldset>',
-        '</div>'
-      ]
-    end
-  end
-
   describe '#radio_button_fieldset' do
-
-    let(:pretty_output) { HtmlBeautifier.beautify output }
 
     context 'outputs radio buttons in a stacked layout' do
       let(:locations) {[:ni, :isle_of_man_channel_islands, :british_abroad]}

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -316,42 +316,43 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
   end
 
   describe '#radio_button_fieldset' do
+
     let(:pretty_output) { HtmlBeautifier.beautify output }
 
-    it 'outputs radio buttons in a stacked layout' do
-      output = builder.radio_button_fieldset :location, choices: [:ni, :isle_of_man_channel_islands, :british_abroad]
-      expect_equal output, [
-        '<div class="form-group">',
-        '<fieldset>',
-        '<legend>',
-        '<span class="form-label-bold">',
-        'Where do you live?',
-        '</span>',
-        '<span class="form-hint">',
-        'Select from these options because you answered you do not reside in England, Wales, or Scotland',
-        '</span>',
-        '</legend>',
-        '<div class="multiple-choice">',
-        '<input type="radio" value="ni" name="person[location]" id="person_location_ni" />',
-        '<label for="person_location_ni">',
-        'Northern Ireland',
-        '</label>',
-        '</div>',
-        '<div class="multiple-choice">',
-        '<input type="radio" value="isle_of_man_channel_islands" name="person[location]" id="person_location_isle_of_man_channel_islands" />',
-        '<label for="person_location_isle_of_man_channel_islands">',
-        'Isle of Man or Channel Islands',
-        '</label>',
-        '</div>',
-        '<div class="multiple-choice">',
-        '<input type="radio" value="british_abroad" name="person[location]" id="person_location_british_abroad" />',
-        '<label for="person_location_british_abroad">',
-        'I am a British citizen living abroad',
-        '</label>',
-        '</div>',
-        '</fieldset>',
-        '</div>'
-      ]
+    context 'outputs radio buttons in a stacked layout' do
+      let(:locations) {[:ni, :isle_of_man_channel_islands, :british_abroad]}
+      subject {builder.radio_button_fieldset :location, choices: locations}
+
+      specify 'outputs a form group containing the correct number of radio buttons' do
+        expect(subject).to have_tag("div.form-group")
+      end
+
+      specify 'includes the appropriate hint in the form' do
+        expect(subject).to have_tag("span.form-hint", text: I18n.t('helpers.hint.person.location'))
+      end
+
+      specify 'radio buttons exist for each of the relevant options' do
+        locations.each do |location|
+          attributes = {type: 'radio', name: 'person[location]'}
+          selector = "input#person_location_#{location}"
+          expect(subject).to have_tag(selector, with: attributes)
+        end
+      end
+
+      specify 'each radio button should have an appropriate label' do
+
+        # :other isn't specified in :locations so won't appear, don't
+        # check for it
+        I18n
+          .t('helpers.label.person.location')
+          .reject{|k,v| k == :other}
+          .each do |k,v|
+          attributes = {for: "person_location_#{k}"}
+          expect(subject).to have_tag('label', with: attributes, text: v)
+        end
+
+      end
+
     end
 
     it 'outputs yes/no choices when no choices specified, and adds "inline" class to fieldset when passed "inline: true"' do

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -195,9 +195,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       end
 
       context 'nested objects (fields_for)' do
-
         context 'nested once' do
-
           let(:address) {Address.new.tap{|a| a.valid?}}
 
           subject do
@@ -219,9 +217,7 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
               name: "person[address_attributes][postcode]"
             })
           end
-
         end
-
 
         context 'nested twice' do
           let(:country) {Country.new.tap{|c| c.valid?}}
@@ -253,46 +249,11 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
               name: "person[address_attributes][country_attributes][name]"
             })
           end
-
         end
-
       end
+
     end
 
-  end
-
-  context 'when mixing the rendering order of nested builders' do
-    let(:method) { :text_field }
-    let(:type) { :text }
-    it 'outputs error messages in span inside label' do
-      resource.address = Address.new
-      resource.address.valid?
-      resource.valid?
-
-      # Render the postcode first
-      builder.fields_for(:address) do |address|
-        address.text_field :postcode
-      end
-      output = builder.text_field :name
-
-      expected = expected_error_html :text_field, :text, 'person_name',
-        'person[name]', 'Full name', 'Full name is required'
-      expect_equal output, expected
-    end
-  end
-
-  def expected_error_html method, type, attribute, name_value, label, error
-    [
-      %'<div class="form-group form-group-error" id="error_#{attribute}">',
-      %'<label class="form-label" for="#{attribute}">',
-      label,
-      %'<span class="error-message" id="error_message_#{attribute}">',
-      error,
-      '</span>',
-      '</label>',
-      %'<#{element_for(method)} aria-describedby="error_message_#{attribute}" class="form-control form-control-error" #{type_for(method, type)}name="#{name_value}" id="#{attribute}" />',
-      '</div>'
-    ]
   end
 
   describe '#text_field' do

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -16,26 +16,6 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
   let(:resource_name) {:person}
   let(:builder) {described_class.new resource_name, resource, helper, {}}
 
-  def expect_equal output, expected
-    split_output = output.gsub(">\n</textarea>", ' />').split("<").join("\n<").split(">").join(">\n").squeeze("\n").strip + '>'
-    split_expected = expected.join("\n")
-    expect(split_output).to eq split_expected
-  end
-
-  def element_for(method)
-    method == :text_area ? 'textarea' : 'input'
-  end
-
-  def type_for(method, type)
-    method == :text_area ? '' : %'type="#{type}" '
-  end
-
-  def html_attributes(hash)
-    if  hash.present?
-      hash.map{|k,v| %'#{k}="#{v}" '}.join(' ')
-    end
-  end
-
   shared_examples_for 'input field' do |method, type|
 
     let(:element) {method.eql?(:text_area) ? "textarea" : "input"}

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -517,122 +517,94 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
   end
 
   describe '#check_box_fieldset' do
-    before do
-      resource.waste_transport = WasteTransport.new
+    before {resource.waste_transport = WasteTransport.new}
+
+    let(:waste_categories) {[:animal_carcasses, :mines_quarries, :farm_agricultural]}
+    subject do
+      builder.fields_for(:waste_transport) {|f| f.check_box_fieldset(:waste_transport, waste_categories)}
     end
 
-    it 'outputs checkboxes wrapped in labels' do
-      resource.waste_transport = WasteTransport.new
-      output = builder.fields_for(:waste_transport) do |f|
-        f.check_box_fieldset :waste_transport, [:animal_carcasses, :mines_quarries, :farm_agricultural]
+    specify 'fieldset has the correct heading' do
+      text = I18n.t('helpers.fieldset.person[waste_transport_attributes].waste_transport')
+      expect(subject).to have_tag('fieldset > legend > span.form-label-bold', text)
+    end
+
+    specify 'outputs checkboxes with labels' do
+      expect(subject).to have_tag('div.form-group') do |form_group|
+        expect(form_group).to have_tag('input', with: {type: 'checkbox'}, count: waste_categories.size)
+        expect(form_group).to have_tag('label', count: waste_categories.size)
       end
-
-      expect_equal output, [
-        '<div class="form-group">',
-        '<fieldset>',
-        '<legend>',
-        '<span class="form-label-bold">',
-        'Which types of waste do you transport regularly?',
-        '</span>',
-        '<span class="form-hint">',
-        'Select all that apply',
-        '</span>',
-        '</legend>',
-        '<div class="multiple-choice">',
-        '<input name="person[waste_transport_attributes][animal_carcasses]" type="hidden" value="0" />',
-        '<input type="checkbox" value="1" name="person[waste_transport_attributes][animal_carcasses]" id="person_waste_transport_attributes_animal_carcasses" />',
-        '<label for="person_waste_transport_attributes_animal_carcasses">',
-        'Waste from animal carcasses',
-        '<br>',
-        '<em>',
-        'includes sloths and other Bradypodidae',
-        '</em>',
-        '</label>',
-        '</div>',
-        '<div class="multiple-choice">',
-        '<input name="person[waste_transport_attributes][mines_quarries]" type="hidden" value="0" />',
-        '<input type="checkbox" value="1" name="person[waste_transport_attributes][mines_quarries]" id="person_waste_transport_attributes_mines_quarries" />',
-        '<label for="person_waste_transport_attributes_mines_quarries">',
-        'Waste from mines or quarries (&gt; 200 lbs)',
-        '</label>',
-        '</div>',
-        '<div class="multiple-choice">',
-        '<input name="person[waste_transport_attributes][farm_agricultural]" type="hidden" value="0" />',
-        '<input type="checkbox" value="1" name="person[waste_transport_attributes][farm_agricultural]" id="person_waste_transport_attributes_farm_agricultural" />',
-        '<label for="person_waste_transport_attributes_farm_agricultural">',
-        'Farm or agricultural waste',
-        '</label>',
-        '</div>',
-        '</fieldset>',
-        '</div>'
-      ]
     end
 
-    it 'outputs markup with support for revealing panels' do
-      resource.waste_transport = WasteTransport.new
-      output = builder.fields_for(:waste_transport) do |f|
-        f.check_box_fieldset :waste_transport, [:animal_carcasses, :mines_quarries, :farm_agricultural] do |fieldset|
-          fieldset.check_box_input(:animal_carcasses)
-          fieldset.check_box_input(:mines_quarries) { f.text_field :mines_quarries_details }
-          fieldset.check_box_input(:farm_agricultural) { f.text_field :farm_agricultural_details }
+    specify 'checkboxes have correct attributes' do
+
+      waste_categories.each do |wc|
+
+        selector = ['person', 'waste_transport_attributes', wc].join('_')
+
+        expect(subject).to have_tag(
+          "input##{selector}",
+          with: {
+            type: 'checkbox',
+            name: "person[waste_transport_attributes][#{wc}]"
+          }
+        )
+
+      end
+    end
+
+    specify 'labels have correct content' do
+      I18n.t('helpers.label.person[waste_transport_attributes]').each do |k,v|
+
+        # this isn't straightforward because Rails's I18n allows for HTML snippets
+        # to be added to the translations, so we need to strip the `_html` suffix
+        # from the key and parse the HTML to extract only the text.
+        target = "person_waste_transport_attributes_#{k}".gsub(/_html$/, "")
+        text = Nokogiri::HTML(v).text
+
+        expect(subject).to have_tag('label', with: {for: target}, text: text)
+      end
+    end
+
+
+    context 'revealing panels' do
+
+      subject do
+        builder.fields_for(:waste_transport) do |f|
+          f.check_box_fieldset :waste_transport, [:animal_carcasses, :mines_quarries, :farm_agricultural] do |fieldset|
+            fieldset.check_box_input(:animal_carcasses)
+            fieldset.check_box_input(:mines_quarries) { f.text_field :mines_quarries_details }
+            fieldset.check_box_input(:farm_agricultural) { f.text_field :farm_agricultural_details }
+          end
         end
       end
 
-      expect_equal output, [
-        '<div class="form-group">',
-        '<fieldset>',
-        '<legend>',
-        '<span class="form-label-bold">',
-        'Which types of waste do you transport regularly?',
-        '</span>',
-        '<span class="form-hint">',
-        'Select all that apply',
-        '</span>',
-        '</legend>',
-        '<div class="multiple-choice">',
-        '<input name="person[waste_transport_attributes][animal_carcasses]" type="hidden" value="0" />',
-        '<input type="checkbox" value="1" name="person[waste_transport_attributes][animal_carcasses]" id="person_waste_transport_attributes_animal_carcasses" />',
-        '<label for="person_waste_transport_attributes_animal_carcasses">',
-        'Waste from animal carcasses',
-        '<br>',
-        '<em>',
-        'includes sloths and other Bradypodidae',
-        '</em>',
-        '</label>',
-        '</div>',
-        '<div class="multiple-choice" data-target="mines_quarries_panel">',
-        '<input name="person[waste_transport_attributes][mines_quarries]" type="hidden" value="0" />',
-        '<input type="checkbox" value="1" name="person[waste_transport_attributes][mines_quarries]" id="person_waste_transport_attributes_mines_quarries" />',
-        '<label for="person_waste_transport_attributes_mines_quarries">',
-        'Waste from mines or quarries (&gt; 200 lbs)',
-        '</label>',
-        '</div>',
-        '<div class="panel panel-border-narrow js-hidden" id="mines_quarries_panel">',
-        '<div class="form-group">',
-        '<label class="form-label" for="person_waste_transport_attributes_mines_quarries_details">',
-        'Mines quarries details',
-        '</label>',
-        '<input class="form-control" type="text" name="person[waste_transport_attributes][mines_quarries_details]" id="person_waste_transport_attributes_mines_quarries_details" />',
-        '</div>',
-        '</div>',
-        '<div class="multiple-choice" data-target="farm_agricultural_panel">',
-        '<input name="person[waste_transport_attributes][farm_agricultural]" type="hidden" value="0" />',
-        '<input type="checkbox" value="1" name="person[waste_transport_attributes][farm_agricultural]" id="person_waste_transport_attributes_farm_agricultural" />',
-        '<label for="person_waste_transport_attributes_farm_agricultural">',
-        'Farm or agricultural waste',
-        '</label>',
-        '</div>',
-        '<div class="panel panel-border-narrow js-hidden" id="farm_agricultural_panel">',
-        '<div class="form-group">',
-        '<label class="form-label" for="person_waste_transport_attributes_farm_agricultural_details">',
-        'Farm agricultural details',
-        '</label>',
-        '<input class="form-control" type="text" name="person[waste_transport_attributes][farm_agricultural_details]" id="person_waste_transport_attributes_farm_agricultural_details" />',
-        '</div>',
-        '</div>',
-        '</fieldset>',
-        '</div>'
-      ]
+      let(:fields_with_hidden_panels) {[:mines_quarries, :farm_agricultural]}
+      let(:field_without_hidden_panel) {:animal_carcasses}
+
+      specify 'inputs are marked as multiple choice' do
+        count = fields_with_hidden_panels.push(field_without_hidden_panel).size
+        expect(subject).to have_tag('div.multiple-choice', count: count)
+      end
+
+      specify 'should not add a text field to checkboxes without associated text fields' do
+        expect(subject).not_to have_tag("div##{field_without_hidden_panel}_panel")
+      end
+
+      specify 'should add a text field to checkboxes with associated text fields' do
+        fields_with_hidden_panels.each do |fwhp|
+          expect(subject).to have_tag("div##{fwhp}_panel") do |panel|
+
+            attributes = {
+              type: 'text',
+              name: "person[waste_transport_attributes][#{fwhp}_details]"
+            }
+
+            expect(panel).to have_tag('div.panel.js-hidden input', with: attributes)
+          end
+        end
+      end
+
     end
 
     it 'outputs markup with support for revealing panels with specific ID' do

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -653,110 +653,78 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       end
       expect(output).to match(/<legend><span class="form-label-bold visuallyhidden" lang="en">/)
     end
-
-    it 'can override the legend text' do
-      output = builder.fields_for(:waste_transport) do |f|
-        f.check_box_fieldset :waste_transport, [:animal_carcasses, :mines_quarries, :farm_agricultural], legend_options: { text: 'A custom legend' }
-      end
-      expect(output).to match(/<legend><span class="form-label-bold">A custom legend<\/span>/)
-    end
   end
 
-  describe '#collection_radio_button' do
-
-     it 'outputs radio buttons in a stacked layout' do
-       person = Person.new
-       gender_collection = [
-           OpenStruct.new(code: 'M', name: 'Masculine'),
-           OpenStruct.new(code: 'F', name: 'Feminine'),
-           OpenStruct.new(code: 'N', name: 'Neuter')
-       ]
-
-       output = builder.collection_radio_buttons :gender, gender_collection,  :code, :name, {id: 'gender-radio-id'}
-
-       expect_equal output, [
-        '<div class="form-group">',
-        '<fieldset>',
-        '<legend>',
-        '<span class="form-label-bold">',
-        'Gender',
-        '</span>',
-        '<span class="form-hint">',
-        'Select from these options',
-        '</span>',
-        '</legend>',
-        '<div class="multiple-choice">',
-        '<input type="radio" value="M" name="person[gender]" id="person_gender_m" />',
-        '<label for="person_gender_m">',
-        'Masculine',
-        '</label>',
-        '</div>',
-        '<div class="multiple-choice">',
-        '<input type="radio" value="F" name="person[gender]" id="person_gender_f" />',
-        '<label for="person_gender_f">',
-        'Feminine',
-        '</label>',
-        '</div>',
-        '<div class="multiple-choice">',
-        '<input type="radio" value="N" name="person[gender]" id="person_gender_n" />',
-        '<label for="person_gender_n">',
-        'Neuter',
-        '</label>',
-        '</div>',
-        '</fieldset>',
-        '</div>'
-       ]
-     end
-
-  end
-
-
-  describe '#collection_check_boxes' do
-
-    it 'outputs check boxes in a stacked layout' do
-      person = Person.new
-      gender_collection = [
+  describe '#collection_radio_buttons' do
+    let(:input_type) {'radio'}
+    let(:person) {Person.new}
+    let(:gender_collection) {
+      [
         OpenStruct.new(code: 'M', name: 'Masculine'),
         OpenStruct.new(code: 'F', name: 'Feminine'),
         OpenStruct.new(code: 'N', name: 'Neuter')
       ]
+    }
 
-      output = builder.collection_check_boxes :gender, gender_collection,  :code, :name, {id: 'gender-radio-id'}
+    let(:output) {
+      builder.collection_radio_buttons :gender, gender_collection, :code, :name, {id: 'gender-radio-id'}
+    }
 
-      expect_equal output, [
-        '<div class="form-group">',
-        '<fieldset>',
-        '<legend>',
-        '<span class="form-label-bold">',
-        'Gender',
-        '</span>',
-        '<span class="form-hint">',
-        'Select from these options',
-        '</span>',
-        '</legend>',
-        '<div class="multiple-choice">',
-        '<input type="checkbox" value="M" name="person[gender][]" id="person_gender_m" />',
-        '<label for="person_gender_m">',
-        'Masculine',
-        '</label>',
-        '</div>',
-        '<div class="multiple-choice">',
-        '<input type="checkbox" value="F" name="person[gender][]" id="person_gender_f" />',
-        '<label for="person_gender_f">',
-        'Feminine',
-        '</label>',
-        '</div>',
-        '<div class="multiple-choice">',
-        '<input type="checkbox" value="N" name="person[gender][]" id="person_gender_n" />',
-        '<label for="person_gender_n">',
-        'Neuter',
-        '</label>',
-        '</div>',
-        # rails adds this hidden field
-        '<input type="hidden" name="person[gender][]" value="" />',
-        '</fieldset>',
-        '</div>'
+    let(:input_container) {'div.form-group > fieldset > div.multiple-choice'}
+
+    specify 'adds the correct number of radio buttons' do
+      expect(output).to have_tag(input_container, count: gender_collection.size)
+    end
+
+    specify 'correctly builds the entries' do
+      gender_collection.each do |gc|
+        attributes = {type: input_type, value: gc.code, name: "person[gender]"}
+        expect(output).to have_tag("#{input_container} > input#person_gender_#{gc.code.downcase}", with: attributes)
+      end
+    end
+  end
+
+
+  describe '#collection_check_boxes' do
+    let(:input_type) {'checkbox'}
+    let(:person) {Person.new}
+    let(:gender_collection) {
+      [
+        OpenStruct.new(code: 'M', name: 'Masculine'),
+        OpenStruct.new(code: 'F', name: 'Feminine'),
+        OpenStruct.new(code: 'N', name: 'Neuter')
       ]
+    }
+
+    let(:output) {
+      builder.collection_check_boxes :gender, gender_collection, :code, :name, {id: 'gender-radio-id'}
+    }
+
+    let(:input_container) {'div.form-group > fieldset > div.multiple-choice'}
+
+    specify 'builds the legend, form label and hint correctly' do
+      expect(output).to have_tag('div.form-group > fieldset > legend') do |legend|
+        expect(legend).to have_tag('span.form-label-bold', text: 'Gender')
+        expect(legend).to have_tag('span.form-hint', text: 'Select from these options')
+      end
+    end
+
+    specify 'adds the correct number of check boxes' do
+      expect(output).to have_tag(input_container, count: gender_collection.size)
+    end
+
+    specify 'correctly builds the entries' do
+      gender_collection.each do |gc|
+        attributes = {type: input_type, value: gc.code, name: "person[gender][]"}
+        expect(output).to have_tag("#{input_container} > input#person_gender_#{gc.code.downcase}", with: attributes)
+      end
+    end
+
+    specify 'correctly labels each check box' do
+      gender_collection.each do |gc|
+        attributes = {for: "person_gender_#{gc.code.downcase}"}
+        expect(output).to have_tag("#{input_container} > label", text: gc.name, with: attributes)
+      end
     end
 
   end

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     expect(GovukElementsFormBuilder::VERSION).to eq("1.3.1")
   end
 
-  let(:helper) { TestHelper.new }
-  let(:resource)  { Person.new }
-  let(:builder) { described_class.new :person, resource, helper, {} }
+  let(:helper) {TestHelper.new}
+  let(:resource) {Person.new}
+  let(:resource_name) {:person}
+  let(:builder) {described_class.new resource_name, resource, helper, {}}
 
   def expect_equal output, expected
     split_output = output.gsub(">\n</textarea>", ' />').split("<").join("\n<").split(">").join(">\n").squeeze("\n").strip + '>'
@@ -37,79 +38,79 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
   shared_examples_for 'input field' do |method, type|
 
-    def size(method, size)
-      (size.nil? || method == :text_area) ? '' : %'size="#{size}" '
-    end
+    let(:element) {method.eql?(:text_area) ? "textarea" : "input"}
 
-    def expected_name_input_html method, type, classes=nil, size=nil, label_options=nil
-      label_options ||= {}
-      label_options[:class] ||= nil
-      [
-        '<div class="form-group">',
-        %'<label #{html_attributes(label_options.except(:class, :for))}class="form-label#{label_options[:class]}" for="person_name">',
-        'Full name',
-        '</label>',
-        %'<#{element_for(method)} #{size(method, size)}class="form-control#{classes}" #{type_for(method, type)}name="person[name]" id="person_name" />',
-        '</div>'
-      ]
-    end
+    let(:attribute) {:name}
+    subject {builder.send(method, attribute)}
 
-    it 'outputs label and input wrapped in div' do
-      output = builder.send method, :name
-
-      expect_equal output, expected_name_input_html(method, type)
-    end
-
-    it 'adds custom class to input when passed class: "custom-class"' do
-      output = builder.send method, :name, class: 'custom-class'
-
-      expect_equal output, expected_name_input_html(method, type, ' custom-class')
-    end
-
-    it 'adds custom classes to input when passed class: ["custom-class", "another-class"]' do
-      output = builder.send method, :name, class: ['custom-class', 'another-class']
-
-      expect_equal output, expected_name_input_html(method, type, ' custom-class another-class')
-    end
-
-    it 'adds custom classes to label when passed class: ["custom-class", "another-class"]' do
-      label_class_options = { class: ' custom-label-class another-label-class' }
-      output = builder.send method, :name, {label_options: {class: ['custom-label-class', 'another-label-class']}}
-
-      expect_equal output, expected_name_input_html( method, type, nil, nil, label_class_options)
-    end
-
-    it 'passes other html attribute to the label if they are provided' do
-      label_attr_options = { style: 'color:red;'}
-      output = builder.send method, :name, {label_options: {style: 'color:red;'}}
-
-      expect_equal output, expected_name_input_html( method, type, nil, nil, label_attr_options)
-    end
-
-    it 'passes options passed to text_field onto super text_field implementation' do
-      output = builder.send method, :name, size: 100
-
-      expect_equal output, expected_name_input_html(method, type, nil, 100)
-    end
-
-    context 'when hint text provided' do
-      it 'outputs hint text in span inside label' do
-        output = builder.send method, :ni_number
-        expect_equal output, [
-          '<div class="form-group">',
-          '<label class="form-label" for="person_ni_number">',
-          'National Insurance number',
-          '<span class="form-hint">',
-          'It’ll be on your last payslip. For example, JH 21 90 0A.',
-          '</span>',
-          '</label>',
-          %'<#{element_for(method)} class="form-control" #{type_for(method, type)}name="person[ni_number]" id="person_ni_number" />',
-          '</div>'
-        ]
+    specify 'outputs label and input wrapped in div' do
+      expect(subject).to have_tag('div.form-group') do |fg|
+        expect(fg).to have_tag(element, with: {name: "#{resource_name}[#{attribute}]"})
+        expect(fg).to have_tag("label.form-label", with: {for: [resource_name, attribute].join('_')})
       end
     end
 
-    context 'when fields_for used' do
+    context 'inputs' do
+
+      context "one custom input class (passed as a string)" do
+        let(:custom_class) {"blue-and-white-stripes"}
+        subject { builder.send(method, :name, class: custom_class) }
+
+        specify 'adds custom class to input when provided' do
+          expect(subject).to have_tag("#{element}.#{custom_class}", with: {type: type}.compact)
+        end
+      end
+
+      context "multiple custom input classes (passed as an array)" do
+        let(:custom_classes) {["blue-and-white-stripes", "yellow-spots"]}
+        subject { builder.send(method, :name, class: custom_classes) }
+
+        specify 'adds multiple custom classes to input when provided' do
+          expect(subject).to have_tag("#{element}.#{custom_classes.join(".")}", with: {type: type}.compact)
+        end
+      end
+
+      context "custom html attributes" do
+
+        let(:custom_attributes) {method.eql?(:text_area) ? {cols: '100'} : {size: '100'}}
+
+        subject {builder.send(method, :name, nil, custom_attributes.dup)}
+
+        specify 'adds all supplied html attributes' do
+          expect(subject).to have_tag(element, with: custom_attributes)
+        end
+
+      end
+
+    end
+
+    context 'labels' do
+
+      context "one custom label attributes" do
+        let(:label_options) {{"data-some-value" => "XYZ", lang: "en"}}
+        subject { builder.send(method, :name, label_options: label_options) }
+
+        specify 'adds custom class to input when provided' do
+          expect(subject).to have_tag("label", with: label_options)
+        end
+      end
+
+    end
+
+    context 'hints' do
+
+      subject {builder.send(method, :ni_number)}
+      let(:hint_text) {I18n.t('helpers.hint.person.ni_number')}
+
+      specify 'should include hint text' do
+        expect(subject).to have_tag('.form-group > label.form-label') do |label|
+          expect(label).to have_tag("span.form-hint", text: hint_text)
+        end
+      end
+
+    end
+
+    context 'fields_for' do
       it 'outputs label and input with correct ids' do
         output = builder.fields_for(:address, Address.new) do |f|
           f.send method, :postcode

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -666,24 +666,37 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       ]
     }
 
-    let(:output) {
+    subject {
       builder.collection_radio_buttons :gender, gender_collection, :code, :name, {id: 'gender-radio-id'}
     }
 
     let(:input_container) {'div.form-group > fieldset > div.multiple-choice'}
 
+    specify 'builds the legend, form label and hint correctly' do
+      expect(subject).to have_tag('div.form-group > fieldset > legend') do |legend|
+        expect(legend).to have_tag('span.form-label-bold', text: 'Gender')
+        expect(legend).to have_tag('span.form-hint', text: 'Select from these options')
+      end
+    end
+
     specify 'adds the correct number of radio buttons' do
-      expect(output).to have_tag(input_container, count: gender_collection.size)
+      expect(subject).to have_tag(input_container, count: gender_collection.size)
     end
 
     specify 'correctly builds the entries' do
       gender_collection.each do |gc|
         attributes = {type: input_type, value: gc.code, name: "person[gender]"}
-        expect(output).to have_tag("#{input_container} > input#person_gender_#{gc.code.downcase}", with: attributes)
+        expect(subject).to have_tag("#{input_container} > input#person_gender_#{gc.code.downcase}", with: attributes)
+      end
+    end
+
+    specify 'correctly labels each radio button' do
+      gender_collection.each do |gc|
+        attributes = {for: "person_gender_#{gc.code.downcase}"}
+        expect(subject).to have_tag("#{input_container} > label", text: gc.name, with: attributes)
       end
     end
   end
-
 
   describe '#collection_check_boxes' do
     let(:input_type) {'checkbox'}
@@ -696,34 +709,34 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       ]
     }
 
-    let(:output) {
+    subject {
       builder.collection_check_boxes :gender, gender_collection, :code, :name, {id: 'gender-radio-id'}
     }
 
     let(:input_container) {'div.form-group > fieldset > div.multiple-choice'}
 
     specify 'builds the legend, form label and hint correctly' do
-      expect(output).to have_tag('div.form-group > fieldset > legend') do |legend|
+      expect(subject).to have_tag('div.form-group > fieldset > legend') do |legend|
         expect(legend).to have_tag('span.form-label-bold', text: 'Gender')
         expect(legend).to have_tag('span.form-hint', text: 'Select from these options')
       end
     end
 
     specify 'adds the correct number of check boxes' do
-      expect(output).to have_tag(input_container, count: gender_collection.size)
+      expect(subject).to have_tag(input_container, count: gender_collection.size)
     end
 
     specify 'correctly builds the entries' do
       gender_collection.each do |gc|
         attributes = {type: input_type, value: gc.code, name: "person[gender][]"}
-        expect(output).to have_tag("#{input_container} > input#person_gender_#{gc.code.downcase}", with: attributes)
+        expect(subject).to have_tag("#{input_container} > input#person_gender_#{gc.code.downcase}", with: attributes)
       end
     end
 
     specify 'correctly labels each check box' do
       gender_collection.each do |gc|
         attributes = {for: "person_gender_#{gc.code.downcase}"}
-        expect(output).to have_tag("#{input_container} > label", text: gc.name, with: attributes)
+        expect(subject).to have_tag("#{input_container} > label", text: gc.name, with: attributes)
       end
     end
 
@@ -732,97 +745,71 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
   describe '#collection_select' do
 
-    it 'outputs label and input wrapped in div ' do
-      @gender = [:male, :female]
-      output = builder.collection_select :gender, @gender , :to_s, :to_s
-      expect_equal output, [
-          '<div class="form-group">',
-          '<label class="form-label" for="person_gender">',
-          'Gender',
-          '<span class="form-hint">',
-          'Select from these options',
-          '</span>',
-          '</label>',
-          %'<select class="form-control" name="person[gender]" id="person_gender">',
-          %'<option value="male">',
-          'male',
-          %'</option>',
-          %'<option value="female">',
-          'female',
-          %'</option>',
-          %'</select>',
-          '</div>'
-      ]
+    let(:genders) {[:male, :female]}
+
+    context 'select element and labels' do
+
+      subject {builder.collection_select(:gender, genders, :to_s, :to_s)}
+
+      specify 'outputs a div containing select and label elements' do
+
+        expect(subject).to have_tag('div.form-group') do |div|
+          expect(div).to have_tag('label.form-label')
+          expect(div).to have_tag('select.form-control')
+        end
+
+      end
+
+      specify 'the label has the correct text and attributes' do
+        selector = 'div.form-group > label.form-label'
+        expect(subject).to have_tag(selector, text: /Gender/, options: {for: 'person_gender'})
+      end
+
+      specify 'the select box has the correct contents' do
+        selector = 'div.form-group > select#person_gender.form-control'
+        attributes = {name: 'person[gender]'}
+
+        expect(subject).to have_tag(selector, with: attributes) do |select|
+          genders.each do |gender|
+            expect(select).to have_tag('option', with: {value: gender}, text: gender)
+          end
+        end
+
+      end
     end
 
-    it 'outputs select lists with labels and hints' do
-      @location = [:ni, :isle_of_man_channel_islands]
-      output = builder.collection_select :location, @location , :to_s, :to_s, {}
-      expect_equal output, [
-          '<div class="form-group">',
-          '<label class="form-label" for="person_location">',
-          '{:ni=&gt;&quot;Northern Ireland&quot;, :isle_of_man_channel_islands=&gt;&quot;Isle of Man or Channel Islands&quot;, :british_abroad=&gt;&quot;I am a British citizen living abroad&quot;, :other=&gt;&quot;Other location&quot;}',
-          %'<span class="form-hint">',
-          'Select from these options because you answered you do not reside in England, Wales, or Scotland',
-          %'</span>',
-          '</label>',
-          %'<select class="form-control" name="person[location]" id="person_location">',
-          %'<option value="ni">',
-          'ni',
-          %'</option>',%'<option value="isle_of_man_channel_islands">',
-          'isle_of_man_channel_islands',
-          %'</option>',
-          %'</select>',
-          '</div>'
-      ]
+    context 'outputs select lists with labels and hints' do
+      let(:locations) {[:ni, :isle_of_man_channel_islands]}
+      let(:hint) {I18n.t('helpers.hint.person.location')}
+
+      subject {builder.collection_select(:location, locations, :to_s, :to_s, {})}
+
+      specify 'should display the correct hints if they are defined' do
+        selector = 'div.form-group > label.form-label'
+        expect(subject).to have_tag(selector, text: hint, options: {for: 'person_location'})
+      end
+
     end
 
-    it 'adds custom class to input when passed class: "custom-class"' do
-      @gender = [:male, :female]
-      output = builder.collection_select :gender, @gender , :to_s, :to_s, {}, class: "my-custom-style"
-      expect_equal output, [
-          '<div class="form-group">',
-          '<label class="form-label" for="person_gender">',
-          'Gender',
-          '<span class="form-hint">',
-          'Select from these options',
-          '</span>',
-          '</label>',
-          %'<select class="form-control my-custom-style" name="person[gender]" id="person_gender">',
-          %'<option value="male">',
-          'male',
-          %'</option>',
-          %'<option value="female">',
-          'female',
-          %'</option>',
-          %'</select>',
-          '</div>'
-      ]
+    context 'custom classes' do
+      let(:custom_class) {"my-custom-style"}
+      subject {builder.collection_select :gender, genders, :to_s, :to_s, {}, class: custom_class}
+
+      specify 'it should add a custom class when one is supplied' do
+        expect(subject).to have_tag("select.#{custom_class}")
+      end
+
     end
-    it 'includes blanks' do
-      @gender = [:male, :female]
-      output = builder.collection_select :gender, @gender , :to_s, :to_s, {include_blank: "Please select an option"}, {class: "my-custom-style"}
-      expect_equal output, [
-          '<div class="form-group">',
-          '<label class="form-label" for="person_gender">',
-          'Gender',
-          '<span class="form-hint">',
-          'Select from these options',
-          '</span>',
-          '</label>',
-          %'<select class="form-control my-custom-style" name="person[gender]" id="person_gender">',
-          %'<option value="">',
-          'Please select an option',
-          %'</option>',
-          %'<option value="male">',
-          'male',
-          %'</option>',
-          %'<option value="female">',
-          'female',
-          %'</option>',
-          %'</select>',
-          '</div>'
-      ]
+
+    context 'blanks' do
+      let(:blank_text) {"Please select an option"}
+      subject {builder.collection_select :gender, genders, :to_s, :to_s, {include_blank: blank_text}}
+
+      specify 'it should add a insert a blank entry when include_blank is supplied' do
+        expect(subject).to have_tag("select > option", text: blank_text, with: {value: ""})
+      end
+
     end
+
   end
 end

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -355,166 +355,152 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
     end
 
-    it 'outputs yes/no choices when no choices specified, and adds "inline" class to fieldset when passed "inline: true"' do
-      output = builder.radio_button_fieldset :has_user_account, inline: true
-      expect_equal output, [
-        '<div class="form-group">',
-        '<fieldset class="inline">',
-        '<legend>',
-        '<span class="form-label-bold">',
-        'Do you already have a personal user account?',
-        '</span>',
-        '</legend>',
-        '<div class="multiple-choice">',
-        '<input type="radio" value="yes" name="person[has_user_account]" id="person_has_user_account_yes" />',
-        '<label for="person_has_user_account_yes">',
-        'Yes',
-        '</label>',
-        '</div>',
-        '<div class="multiple-choice">',
-        '<input type="radio" value="no" name="person[has_user_account]" id="person_has_user_account_no" />',
-        '<label for="person_has_user_account_no">',
-        'No',
-        '</label>',
-        '</div>',
-        '</fieldset>',
-        '</div>'
-      ]
-    end
+    context 'when no choices specified' do
 
-    it 'outputs markup with support for revealing panels' do
-      output = builder.radio_button_fieldset :location do |fieldset|
-        fieldset.radio_input(:england)
-        fieldset.radio_input(:other) {
-          fieldset.text_field :location_other
-        }
+      subject {builder.radio_button_fieldset(:has_user_account)}
+
+      specify 'outputs yes/no choices' do
+        expect(subject).to have_tag('.form-group > fieldset') do |fieldset|
+          expect(fieldset).to have_tag('div.multiple-choice > input', count: 2, with: {type: 'radio'})
+          expect(fieldset).to have_tag('input', with: {value: 'no'})
+          expect(fieldset).to have_tag('input', with: {value: 'yes'})
+        end
       end
 
-      expect_equal output, [
-      '<div class="form-group">',
-        '<fieldset>',
-        '<legend>',
-        '<span class="form-label-bold">',
-        'Where do you live?',
-        '</span>',
-        '<span class="form-hint">',
-        'Select from these options because you answered you do not reside in England, Wales, or Scotland',
-        '</span>',
-        '</legend>',
-        '<div class="multiple-choice">',
-        '<input type="radio" value="england" name="person[location]" id="person_location_england" />',
-        '<label for="person_location_england">',
-        'England',
-        '</label>',
-        '</div>',
-        '<div class="multiple-choice" data-target="location_other_panel">',
-        '<input type="radio" value="other" name="person[location]" id="person_location_other" />',
-        '<label for="person_location_other">',
-        'Other location',
-        '</label>',
-        '</div>',
-        '<div class="panel panel-border-narrow js-hidden" id="location_other_panel">',
-        '<div class="form-group">',
-        '<label class="form-label" for="person_location_other">',
-        'Please enter your location',
-        '</label>',
-        '<input class="form-control" type="text" name="person[location_other]" id="person_location_other" />',
-        '</div>',
-        '</div>',
-        '</fieldset>',
-        '</div>'
-      ]
-    end
-
-    it 'outputs markup with support for revealing panels with specific ID' do
-      output = builder.radio_button_fieldset :location do |fieldset|
-        fieldset.radio_input(:england)
-        fieldset.radio_input(:other, panel_id: 'another_location_input')
+      specify 'yes/no choices have labels' do
+        expect(subject).to have_tag('.form-group > fieldset') do |fieldset|
+          expect(fieldset).to have_tag('label', text: 'Yes', with: {for: 'person_has_user_account_yes'})
+          expect(fieldset).to have_tag('label', text: 'No', with: {for: 'person_has_user_account_no'})
+        end
       end
 
-      expect(output).to match(/<div class="multiple-choice" data-target="another_location_input">/)
     end
 
-    it 'propagates html attributes down to the legend inner span if any provided, appending to the defaults' do
-      output = builder.radio_button_fieldset :has_user_account, inline: true, legend_options: {class: 'visuallyhidden', lang: 'en'}
-      expect(output).to match(/<legend><span class="form-label-bold visuallyhidden" lang="en">/)
-    end
+    context 'adds inline class to fieldset when inline option passed' do
+      subject {builder.radio_button_fieldset(:has_user_account, inline: true)}
 
-    it 'can override the legend text' do
-      output = builder.radio_button_fieldset :has_user_account, inline: true, legend_options: { text: 'A custom legend' }
-      expect(output).to match(/<legend><span class="form-label-bold">A custom legend<\/span>/)
-    end
-
-    context 'with a couple associated cases' do
-      let(:case_1) { Case.new(id: 1, name: 'Case One')  }
-      let(:case_2) { Case.new(id: 2, name: 'Case Two')  }
-      let(:cases) { [case_1, case_2] }
-
-      it 'accepts value_method and text_method to better control generated HTML' do
-        output = builder.radio_button_fieldset :case_id, choices: cases, value_method: :id, text_method: :name, inline: true
-        expect_equal output, [
-                       '<div class="form-group">',
-                       '<fieldset class="inline">',
-                       '<legend>',
-                       '<span class="form-label-bold">',
-                       'Case',
-                       '</span>',
-                       '</legend>',
-                       '<div class="multiple-choice">',
-                       '<input type="radio" value="1" name="person[case_id]" id="person_case_id_1" />',
-                       '<label for="person_case_id_1">',
-                       'Case One',
-                       '</label>',
-                       '</div>',
-                       '<div class="multiple-choice">',
-                       '<input type="radio" value="2" name="person[case_id]" id="person_case_id_2" />',
-                       '<label for="person_case_id_2">',
-                       'Case Two',
-                       '</label>',
-                       '</div>',
-                       '</fieldset>',
-                       '</div>'
-                     ]
-
+      specify "fieldset should have 'inline' class" do
+        expect(subject).to have_tag('.form-group > fieldset.inline')
       end
     end
 
-    context 'the resource is invalid' do
-      let(:resource) { Person.new.tap { |p| p.valid? } }
+    context 'revealing panels' do
 
-      it 'outputs error messages' do
-        output = builder.radio_button_fieldset :gender
-        expect_equal output, [
-                       '<div class="form-group form-group-error" id="error_person_gender">',
-                       '<fieldset>',
-                       '<legend>',
-                       '<span class="form-label-bold">',
-                       'Gender',
-                       '</span>',
-                       '<span class="error-message">',
-                       'Gender is required',
-                       '</span>',
-                       '<span class="form-hint">',
-                       'Select from these options',
-                       '</span>',
-                       '</legend>',
-                       '<div class="multiple-choice">',
-                       '<input aria-describedby="error_message_person_gender_yes" type="radio" value="yes" name="person[gender]" id="person_gender_yes" />',
-                       '<label for="person_gender_yes">',
-                       'Yes',
-                       '</label>',
-                       '</div>',
-                       '<div class="multiple-choice">',
-                       '<input aria-describedby="error_message_person_gender_no" type="radio" value="no" name="person[gender]" id="person_gender_no" />',
-                       '<label for="person_gender_no">',
-                       'No',
-                       '</label>',
-                       '</div>',
-                       '</fieldset>',
-                       '</div>'
-                     ]
+      let(:other_input) {:location_other}
+      let(:other_input_panel) {:location_other_panel}
+      let(:other_input_label) { I18n.t('label.location_other') }
+
+      subject do
+        builder.radio_button_fieldset(:location) do |fieldset|
+          fieldset.radio_input(:england)
+          fieldset.radio_input(:other) {
+            fieldset.text_field other_input
+          }
+        end
+      end
+
+      specify "there should be an 'other' entry" do
+        target_options = {'data-target' => other_input_panel}
+        expect(subject).to have_tag('.multiple-choice', with: target_options) do
+          expect(subject).to have_tag('input', with: {
+            type: 'radio',
+            value: 'other'
+          })
+        end
+      end
+
+      specify "there should be a hidden panel for the 'other' entry" do
+        expect(subject).to have_tag(".panel.js-hidden", with: {id: other_input_panel})
+      end
+
+      specify 'the hidden panel should contain a text input' do
+        expect(subject).to have_tag(".panel.js-hidden") do |panel|
+          expect(panel).to have_tag('input.form-control', with: {
+            type: 'text',
+            name: "person[#{other_input}]"
+          })
+        end
+      end
+
+      specify "the hidden 'other' input should be labelled correctly" do
+        expect(subject).to have_tag(".panel.js-hidden") do |panel|
+          expect(panel).to have_tag('label.form-label', with: {
+            for: "person_#{other_input}"
+          })
+        end
       end
     end
+
+    context 'revealing panels with a specific id' do
+
+      let(:custom_div) {"a-customisable-div"}
+
+      subject do
+        builder.radio_button_fieldset :location do |fieldset|
+          fieldset.radio_input(:england)
+          fieldset.radio_input(:other, panel_id: custom_div)
+        end
+      end
+
+      specify 'outputs markup with support for revealing panels with specific id' do
+        expect(subject).to have_tag('.multiple-choice', with: {"data-target" => custom_div})
+      end
+
+    end
+
+    context 'legend options' do
+      let(:custom_class) {"bright-pink"}
+      let(:language) {"en"}
+
+      subject do
+        builder.radio_button_fieldset :has_user_account, inline: true, legend_options: {class: custom_class, lang: language}
+      end
+
+      specify 'should be propagated down to the inner legend when provided' do
+        expect(subject).to have_tag("legend > span.form-label-bold.#{custom_class}", with: {lang: language})
+      end
+
+    end
+
+    context 'custom names and values' do
+      let(:cases) {[ Case.new(id: 18, name: 'Case One'), Case.new(id: 19, name: 'Case Two')]}
+      subject {builder.radio_button_fieldset(:case_id, choices: cases, value_method: :id, text_method: :name)}
+
+      specify 'name and value should match provided options' do
+        cases.each do |kase|
+
+          expect(subject).to have_tag("input#person_case_id_#{kase.id}", with: {
+            value: kase.id,
+            type: 'radio'
+          })
+
+          expect(subject).to have_tag('label', text: kase.name, with: {
+            for: "person_case_id_#{kase.id}"
+          })
+
+        end
+      end
+    end
+
+    context 'when the resource is invalid' do
+      let(:resource) {Person.new}
+      let(:error_message) {"Gender is required"}
+      subject {builder.radio_button_fieldset :gender}
+
+      before do
+        resource.valid?
+      end
+
+      specify 'the form group should have error classes' do
+        expect(subject).to have_tag('.form-group.form-group-error')
+      end
+
+      specify 'the form group should have error messages' do
+        expect(subject).to have_tag('.form-group-error span.error-message', text: error_message)
+      end
+
+    end
+
   end
 
   describe '#check_box_fieldset' do

--- a/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
+++ b/spec/lib/govuk_elements_form_builder/form_builder_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     subject {builder.send(method, attribute)}
 
     specify 'outputs label and input wrapped in div' do
-      expect(subject).to have_tag('div.form-group') do |fg|
-        expect(fg).to have_tag(element, with: {name: "#{resource_name}[#{attribute}]"})
-        expect(fg).to have_tag("label.form-label", with: {for: [resource_name, attribute].join('_')})
+      expect(subject).to have_tag('div.form-group') do
+        with_tag(element, with: {name: "#{resource_name}[#{attribute}]"})
+        with_tag("label.form-label", with: {for: [resource_name, attribute].join('_')})
       end
     end
 
@@ -83,8 +83,8 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       let(:hint_text) {I18n.t('helpers.hint.person.ni_number')}
 
       specify 'should include hint text' do
-        expect(subject).to have_tag('.form-group > label.form-label') do |label|
-          expect(label).to have_tag("span.form-hint", text: hint_text)
+        expect(subject).to have_tag('.form-group > label.form-label') do
+          with_tag("span.form-hint", text: hint_text)
         end
       end
 
@@ -130,10 +130,9 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       before {resource.valid?}
 
       specify 'error message is displayed within the label' do
-
-        expect(subject).to have_tag("#error_person_#{attribute}.form-group-error") do |fge|
-          expect(fge).to have_tag('label', text: /Full name/, with: {for: "person_#{attribute}"}) do |label|
-            expect(label).to have_tag('span', text: 'Full name is required')
+        expect(subject).to have_tag("#error_person_#{attribute}.form-group-error") do
+          with_tag('label', text: /Full name/, with: {for: "person_#{attribute}"}) do
+            with_tag('span', text: 'Full name is required')
           end
         end
       end
@@ -166,8 +165,8 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
             # a before block
             resource.valid?
 
-            expect(builder.send(method, attribute)).to have_tag("#error_person_#{attribute}.form-group-error") do |fge|
-              expect(fge).to have_tag('span', text: message)
+            expect(builder.send(method, attribute)).to have_tag("#error_person_#{attribute}.form-group-error") do
+              with_tag('span', text: message)
             end
 
           end
@@ -319,17 +318,17 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       subject {builder.radio_button_fieldset(:has_user_account)}
 
       specify 'outputs yes/no choices' do
-        expect(subject).to have_tag('.form-group > fieldset') do |fieldset|
-          expect(fieldset).to have_tag('div.multiple-choice > input', count: 2, with: {type: 'radio'})
-          expect(fieldset).to have_tag('input', with: {value: 'no'})
-          expect(fieldset).to have_tag('input', with: {value: 'yes'})
+        expect(subject).to have_tag('.form-group > fieldset') do
+          with_tag('div.multiple-choice > input', count: 2, with: {type: 'radio'})
+          with_tag('input', with: {value: 'no'})
+          with_tag('input', with: {value: 'yes'})
         end
       end
 
       specify 'yes/no choices have labels' do
-        expect(subject).to have_tag('.form-group > fieldset') do |fieldset|
-          expect(fieldset).to have_tag('label', text: 'Yes', with: {for: 'person_has_user_account_yes'})
-          expect(fieldset).to have_tag('label', text: 'No', with: {for: 'person_has_user_account_no'})
+        expect(subject).to have_tag('.form-group > fieldset') do
+          with_tag('label', text: 'Yes', with: {for: 'person_has_user_account_yes'})
+          with_tag('label', text: 'No', with: {for: 'person_has_user_account_no'})
         end
       end
 
@@ -373,8 +372,8 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       end
 
       specify 'the hidden panel should contain a text input' do
-        expect(subject).to have_tag(".panel.js-hidden") do |panel|
-          expect(panel).to have_tag('input.form-control', with: {
+        expect(subject).to have_tag(".panel.js-hidden") do
+          with_tag('input.form-control', with: {
             type: 'text',
             name: "person[#{other_input}]"
           })
@@ -382,8 +381,8 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
       end
 
       specify "the hidden 'other' input should be labelled correctly" do
-        expect(subject).to have_tag(".panel.js-hidden") do |panel|
-          expect(panel).to have_tag('label.form-label', with: {
+        expect(subject).to have_tag(".panel.js-hidden") do
+          with_tag('label.form-label', with: {
             for: "person_#{other_input}"
           })
         end
@@ -477,8 +476,8 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
     specify 'outputs checkboxes with labels' do
       expect(subject).to have_tag('div.form-group') do |form_group|
-        expect(form_group).to have_tag('input', with: {type: 'checkbox'}, count: waste_categories.size)
-        expect(form_group).to have_tag('label', count: waste_categories.size)
+        with_tag('input', with: {type: 'checkbox'}, count: waste_categories.size)
+        with_tag('label', count: waste_categories.size)
       end
     end
 
@@ -539,14 +538,14 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
       specify 'should add a text field to checkboxes with associated text fields' do
         fields_with_hidden_panels.each do |fwhp|
-          expect(subject).to have_tag("div##{fwhp}_panel") do |panel|
+          expect(subject).to have_tag("div##{fwhp}_panel") do
 
             attributes = {
               type: 'text',
               name: "person[waste_transport_attributes][#{fwhp}_details]"
             }
 
-            expect(panel).to have_tag('div.panel.js-hidden input', with: attributes)
+            with_tag('div.panel.js-hidden input', with: attributes)
           end
         end
       end
@@ -591,9 +590,9 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     let(:input_container) {'div.form-group > fieldset > div.multiple-choice'}
 
     specify 'builds the legend, form label and hint correctly' do
-      expect(subject).to have_tag('div.form-group > fieldset > legend') do |legend|
-        expect(legend).to have_tag('span.form-label-bold', text: 'Gender')
-        expect(legend).to have_tag('span.form-hint', text: 'Select from these options')
+      expect(subject).to have_tag('div.form-group > fieldset > legend') do
+        with_tag('span.form-label-bold', text: 'Gender')
+        with_tag('span.form-hint', text: 'Select from these options')
       end
     end
 
@@ -634,9 +633,9 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
     let(:input_container) {'div.form-group > fieldset > div.multiple-choice'}
 
     specify 'builds the legend, form label and hint correctly' do
-      expect(subject).to have_tag('div.form-group > fieldset > legend') do |legend|
-        expect(legend).to have_tag('span.form-label-bold', text: 'Gender')
-        expect(legend).to have_tag('span.form-hint', text: 'Select from these options')
+      expect(subject).to have_tag('div.form-group > fieldset > legend') do
+        with_tag('span.form-label-bold', text: 'Gender')
+        with_tag('span.form-hint', text: 'Select from these options')
       end
     end
 
@@ -671,9 +670,9 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
 
       specify 'outputs a div containing select and label elements' do
 
-        expect(subject).to have_tag('div.form-group') do |div|
-          expect(div).to have_tag('label.form-label')
-          expect(div).to have_tag('select.form-control')
+        expect(subject).to have_tag('div.form-group') do
+          with_tag('label.form-label')
+          with_tag('select.form-control')
         end
 
       end
@@ -687,9 +686,9 @@ RSpec.describe GovukElementsFormBuilder::FormBuilder do
         selector = 'div.form-group > select#person_gender.form-control'
         attributes = {name: 'person[gender]'}
 
-        expect(subject).to have_tag(selector, with: attributes) do |select|
+        expect(subject).to have_tag(selector, with: attributes) do
           genders.each do |gender|
-            expect(select).to have_tag('option', with: {value: gender}, text: gender)
+            with_tag('option', with: {value: gender}, text: gender)
           end
         end
 


### PR DESCRIPTION
When we forked this library in December 2018 the first step on the way to making it Design System compliant (#105) was to make the specs easier to work with, namely by removing the chunks of HTML and replacing them with RSpec HTML Matchers. This will provide extra flexibility when underlying versions change and the output format/indentation changes slightly, plus it makes the library easier to work with in general.

This PR includes just our fixing of the specs and omits all of the Design System migration stuff added later.

Note, I'm struggling to get Ruby 2.3.1 running on my machine so can't test locally 😞 I don't know whether a version bump would be welcome here - if the tests all pass I think that would make a logical next step. If some fail then we can work out how to solve it then!